### PR TITLE
fix: cleanup legacy named recipe button entities

### DIFF
--- a/custom_components/melitta_barista/__init__.py
+++ b/custom_components/melitta_barista/__init__.py
@@ -32,18 +32,41 @@ def _async_cleanup_legacy_recipe_buttons(
 ) -> None:
     """Remove old per-recipe button entities left from versions before v0.6.0.
 
-    Previously each recipe had its own button (unique_id = {address}_brew_{200..223}).
+    Previously each recipe had its own button. Two unique_id formats existed:
+    - Numeric: {address}_brew_{200..223}
+    - Named:  {address}_brew_{recipe_name} (e.g. _brew_americano)
     Now there is a single Brew button + Recipe select entity.
     """
     registry = er.async_get(hass)
-    # Old recipe button unique_ids: {address}_brew_200 .. {address}_brew_223
     removed = 0
+
+    # Format 1: numeric IDs {address}_brew_200 .. {address}_brew_223
     for recipe_value in range(200, 224):
         unique_id = f"{address}_brew_{recipe_value}"
         entity_id = registry.async_get_entity_id("button", DOMAIN, unique_id)
         if entity_id:
             registry.async_remove(entity_id)
             removed += 1
+
+    # Format 2: named IDs {address}_brew_{enum_name}
+    from .const import RecipeId  # noqa: PLC0415
+    for recipe in RecipeId:
+        unique_id = f"{address}_brew_{recipe.name.lower()}"
+        entity_id = registry.async_get_entity_id("button", DOMAIN, unique_id)
+        if entity_id:
+            registry.async_remove(entity_id)
+            removed += 1
+
+    # Format 3: any remaining button entities with _brew_ pattern in unique_id
+    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if (
+            ent.domain == "button"
+            and "_brew_" in (ent.unique_id or "")
+            and ent.unique_id != f"{address}_brew"
+        ):
+            registry.async_remove(ent.entity_id)
+            removed += 1
+
     if removed:
         _LOGGER.info("Cleaned up %d legacy recipe button entities", removed)
 

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -17,5 +17,5 @@
     "bleak-retry-connector>=3.0.0",
     "pycryptodome>=3.0.0"
   ],
-  "version": "0.6.4"
+  "version": "0.6.5"
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -136,3 +136,45 @@ async def test_legacy_cleanup_removes_old_entities(
         if "_brew_2" in e.unique_id  # legacy pattern: _brew_200, _brew_201, ...
     ]
     assert len(remaining) == 0
+
+
+async def test_legacy_cleanup_removes_named_entities(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test that legacy named recipe button entities are cleaned up."""
+    mock_entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    # Create legacy entities with named unique_ids
+    for name in ("espresso", "americano", "cappuccino"):
+        registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{MOCK_ADDRESS}_brew_{name}",
+            config_entry=mock_entry,
+        )
+
+    assert len(er.async_entries_for_config_entry(registry, mock_entry.entry_id)) == 3
+
+    with (
+        patch(
+            "custom_components.melitta_barista.MelittaBleClient",
+            return_value=_mock_client(),
+        ),
+        patch(
+            "custom_components.melitta_barista.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ),
+        patch(
+            "custom_components.melitta_barista.bluetooth.async_register_callback",
+            return_value=lambda: None,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    remaining = [
+        e for e in er.async_entries_for_config_entry(registry, mock_entry.entry_id)
+        if "_brew_" in e.unique_id
+    ]
+    assert len(remaining) == 0


### PR DESCRIPTION
## Summary
- Expand legacy cleanup to handle named unique_id format (`{address}_brew_americano`)
- Add catch-all cleanup for any remaining `_brew_` pattern entities
- Fixes "no unique_id" warnings for 24 legacy per-recipe buttons
- Bump version to 0.6.5

## Test plan
- [x] 108 tests pass (added test for named cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)