### PR TITLE
fix: instant entity availability on BLE reconnect

### DIFF
--- a/custom_components/melitta_barista/button.py
+++ b/custom_components/melitta_barista/button.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -79,6 +79,13 @@ class _MelittaButtonBase(ButtonEntity):
             manufacturer="Melitta",
             model=self._client.model_name,
         )
+
+    async def async_added_to_hass(self) -> None:
+        self._client.add_connection_callback(self._on_connection_change)
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
+        self.async_write_ha_state()
 
 
 class MelittaBrewButton(_MelittaButtonBase):

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -17,5 +17,5 @@
     "bleak-retry-connector>=3.0.0",
     "pycryptodome>=3.0.0"
   ],
-  "version": "0.6.5"
+  "version": "0.6.6"
 }

--- a/custom_components/melitta_barista/number.py
+++ b/custom_components/melitta_barista/number.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -111,6 +111,13 @@ class MelittaSettingNumber(NumberEntity):
     @property
     def available(self) -> bool:
         return self._client.connected
+
+    async def async_added_to_hass(self) -> None:
+        self._client.add_connection_callback(self._on_connection_change)
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
+        self.async_write_ha_state()
 
     async def async_update(self) -> None:
         value = await self._client.read_setting(self._setting_id)

--- a/custom_components/melitta_barista/select.py
+++ b/custom_components/melitta_barista/select.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -78,6 +78,13 @@ class MelittaRecipeSelect(SelectEntity):
     @property
     def available(self) -> bool:
         return self._client.connected
+
+    async def async_added_to_hass(self) -> None:
+        self._client.add_connection_callback(self._on_connection_change)
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
+        self.async_write_ha_state()
 
     async def async_select_option(self, option: str) -> None:
         """Select a recipe (does not brew — use the Brew button)."""

--- a/custom_components/melitta_barista/sensor.py
+++ b/custom_components/melitta_barista/sensor.py
@@ -95,9 +95,14 @@ class _MelittaSensorBase(SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         self._client.add_status_callback(self._on_status_update)
+        self._client.add_connection_callback(self._on_connection_change)
 
     @callback
     def _on_status_update(self, status: MachineStatus) -> None:
+        self.async_write_ha_state()
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
         self.async_write_ha_state()
 
 
@@ -208,10 +213,6 @@ class MelittaConnectionSensor(_MelittaSensorBase):
     _attr_icon = "mdi:bluetooth-connect"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    async def async_added_to_hass(self) -> None:
-        await super().async_added_to_hass()
-        self._client.add_connection_callback(self._on_connection_change)
-
     @property
     def unique_id(self) -> str:
         return f"{self._client.address}_connection"
@@ -223,10 +224,6 @@ class MelittaConnectionSensor(_MelittaSensorBase):
     @property
     def icon(self) -> str:
         return "mdi:bluetooth-connect" if self._client.connected else "mdi:bluetooth-off"
-
-    @callback
-    def _on_connection_change(self, connected: bool) -> None:
-        self.async_write_ha_state()
 
 
 class MelittaFirmwareSensor(_MelittaSensorBase):

--- a/custom_components/melitta_barista/switch.py
+++ b/custom_components/melitta_barista/switch.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -95,6 +95,13 @@ class MelittaSettingSwitch(SwitchEntity):
     @property
     def available(self) -> bool:
         return self._client.connected
+
+    async def async_added_to_hass(self) -> None:
+        self._client.add_connection_callback(self._on_connection_change)
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
+        self.async_write_ha_state()
 
     async def async_update(self) -> None:
         value = await self._client.read_setting(self._setting_id)

--- a/custom_components/melitta_barista/text.py
+++ b/custom_components/melitta_barista/text.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.components.text import TextEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -74,6 +74,13 @@ class MelittaProfileNameText(TextEntity):
     @property
     def available(self) -> bool:
         return self._client.connected
+
+    async def async_added_to_hass(self) -> None:
+        self._client.add_connection_callback(self._on_connection_change)
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
+        self.async_write_ha_state()
 
     async def async_update(self) -> None:
         value = await self._client.read_alpha(self._name_id)


### PR DESCRIPTION
## Summary
- All entities now register a connection callback via `async_added_to_hass`
- On BLE disconnect: entities immediately become unavailable in UI
- On BLE reconnect: entities immediately become active again
- Previously only the Connection sensor reacted; all others stayed "unavailable" until next poll
- Bump version to 0.6.6

## Affected platforms
- `sensor.py` — base class now handles connection callback (removed duplicate from ConnectionSensor)
- `button.py` — base class `_MelittaButtonBase`
- `select.py` — `MelittaRecipeSelect`
- `switch.py` — `MelittaSettingSwitch`
- `number.py` — `MelittaSettingNumber`
- `text.py` — `MelittaProfileNameText`

## Test plan
- [x] 108 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)