### PR TITLE
feat: profile select & freestyle recipe support

### DIFF
--- a/custom_components/melitta_barista/__init__.py
+++ b/custom_components/melitta_barista/__init__.py
@@ -6,10 +6,12 @@ import asyncio
 import logging
 
 from homeassistant.components import bluetooth
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, Platform
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 
 from .ble_client import MelittaBleClient
 from .const import DOMAIN
@@ -133,6 +135,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _LOGGER.debug("Platforms forwarded")
 
+    # Register freestyle service (once per integration)
+    _async_register_services(hass)
+
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     # Connect in background so we don't block HA setup
@@ -163,6 +168,94 @@ async def _async_connect_and_poll(client: MelittaBleClient) -> None:
         _LOGGER.exception(
             "Unexpected error connecting to %s", client.address
         )
+
+
+SERVICE_BREW_FREESTYLE = "brew_freestyle"
+
+_PROCESS_MAP = {"none": 0, "coffee": 1, "steam": 2, "water": 3}
+_INTENSITY_MAP = {"very_mild": 0, "mild": 1, "medium": 2, "strong": 3, "very_strong": 4}
+_TEMPERATURE_MAP = {"cold": 0, "normal": 1, "high": 2}
+_SHOTS_MAP = {"none": 0, "one": 1, "two": 2, "three": 3}
+
+BREW_FREESTYLE_SCHEMA = vol.Schema({
+    vol.Required("entity_id"): cv.entity_id,
+    vol.Required("name", default="Custom"): cv.string,
+    vol.Required("process1", default="coffee"): vol.In(_PROCESS_MAP),
+    vol.Optional("intensity1", default="medium"): vol.In(_INTENSITY_MAP),
+    vol.Optional("portion1_ml", default=40): vol.All(int, vol.Range(min=5, max=250)),
+    vol.Optional("temperature1", default="normal"): vol.In(_TEMPERATURE_MAP),
+    vol.Optional("shots1", default="one"): vol.In(_SHOTS_MAP),
+    vol.Optional("process2", default="none"): vol.In(_PROCESS_MAP),
+    vol.Optional("intensity2", default="medium"): vol.In(_INTENSITY_MAP),
+    vol.Optional("portion2_ml", default=0): vol.All(int, vol.Range(min=0, max=250)),
+    vol.Optional("temperature2", default="normal"): vol.In(_TEMPERATURE_MAP),
+    vol.Optional("shots2", default="none"): vol.In(_SHOTS_MAP),
+})
+
+
+def _async_register_services(hass: HomeAssistant) -> None:
+    """Register integration services (idempotent)."""
+    if hass.services.has_service(DOMAIN, SERVICE_BREW_FREESTYLE):
+        return
+
+    from .protocol import RecipeComponent  # noqa: PLC0415
+
+    async def _handle_brew_freestyle(call: ServiceCall) -> None:
+        """Handle brew_freestyle service call."""
+        entity_id = call.data["entity_id"]
+
+        # Find the client from config entries
+        client: MelittaBleClient | None = None
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if hasattr(entry, "runtime_data") and entry.runtime_data:
+                c: MelittaBleClient = entry.runtime_data
+                registry = er.async_get(hass)
+                ent = registry.async_get(entity_id)
+                if ent and c.address in (ent.unique_id or ""):
+                    client = c
+                    break
+                # Fallback: use first available client
+                if client is None:
+                    client = c
+
+        if client is None:
+            _LOGGER.error("No Melitta machine found for %s", entity_id)
+            return
+
+        comp1 = RecipeComponent(
+            process=_PROCESS_MAP[call.data["process1"]],
+            shots=_SHOTS_MAP[call.data.get("shots1", "one")],
+            blend=1,  # BLEND_1
+            intensity=_INTENSITY_MAP[call.data.get("intensity1", "medium")],
+            aroma=0,  # STANDARD
+            temperature=_TEMPERATURE_MAP[call.data.get("temperature1", "normal")],
+            portion=call.data.get("portion1_ml", 40) // 5,
+        )
+
+        comp2 = RecipeComponent(
+            process=_PROCESS_MAP[call.data.get("process2", "none")],
+            shots=_SHOTS_MAP[call.data.get("shots2", "none")],
+            blend=0,  # BARISTA_T
+            intensity=_INTENSITY_MAP[call.data.get("intensity2", "medium")],
+            aroma=0,
+            temperature=_TEMPERATURE_MAP[call.data.get("temperature2", "normal")],
+            portion=call.data.get("portion2_ml", 0) // 5,
+        )
+
+        from .const import FREESTYLE_RECIPE_TYPE  # noqa: PLC0415
+        success = await client.brew_freestyle(
+            name=call.data["name"],
+            recipe_type=FREESTYLE_RECIPE_TYPE,
+            component1=comp1,
+            component2=comp2,
+        )
+        if not success:
+            _LOGGER.error("Failed to brew freestyle recipe")
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_BREW_FREESTYLE, _handle_brew_freestyle,
+        schema=BREW_FREESTYLE_SCHEMA,
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/melitta_barista/ble_client.py
+++ b/custom_components/melitta_barista/ble_client.py
@@ -70,6 +70,7 @@ class MelittaBleClient:
         self._reconnect_task: asyncio.Task | None = None
         self._auto_reconnect = True
         self.selected_recipe: RecipeId | None = None
+        self.active_profile: int = 0  # 0 = default "My Coffee"
 
         # Pre-detect machine type from BLE device name if available
         if device_name:
@@ -372,22 +373,42 @@ class MelittaBleClient:
     # High-level API
 
     async def brew_recipe(self, recipe_id: RecipeId) -> bool:
-        """Brew a recipe using the 3-step protocol: HJ -> HB -> HE."""
+        """Brew a recipe using the 3-step protocol: HJ -> HB -> HE.
+
+        If active_profile > 0, reads the profile-customized recipe via DirectKey.
+        """
         if not self.connected:
             return False
         if self._status and not self._status.is_ready:
             _LOGGER.warning("Machine not ready: %s", self._status)
             return False
 
-        from .const import RECIPE_NAMES
+        from .const import (
+            RECIPE_NAMES,
+            RECIPE_TO_DIRECTKEY,
+            TEMP_RECIPE_ID,
+            FREESTYLE_NAME_ID,
+            get_directkey_id,
+        )
 
-        recipe = await self._protocol.read_recipe(self._write_ble, recipe_id)
+        # Determine which recipe ID to read
+        read_id = recipe_id
+        if self.active_profile > 0:
+            dk_cat = RECIPE_TO_DIRECTKEY.get(recipe_id)
+            if dk_cat is not None:
+                read_id = get_directkey_id(self.active_profile, dk_cat)
+                _LOGGER.debug(
+                    "Using DirectKey %d for profile %d, category %s",
+                    read_id, self.active_profile, dk_cat.name,
+                )
+
+        recipe = await self._protocol.read_recipe(self._write_ble, read_id)
         if not recipe:
-            _LOGGER.error("Failed to read recipe %d", recipe_id)
+            _LOGGER.error("Failed to read recipe %d", read_id)
             return False
 
         if not await self._protocol.write_recipe(
-            self._write_ble, 400, recipe.recipe_type, 0,
+            self._write_ble, TEMP_RECIPE_ID, recipe.recipe_type, 0,
             recipe.component1, recipe.component2,
         ):
             _LOGGER.error("Failed to write recipe to temp slot")
@@ -396,8 +417,47 @@ class MelittaBleClient:
         await asyncio.sleep(0.2)
 
         name = RECIPE_NAMES.get(recipe_id, str(recipe_id))
-        if not await self._protocol.write_alphanumeric(self._write_ble, 401, name):
+        if not await self._protocol.write_alphanumeric(
+            self._write_ble, FREESTYLE_NAME_ID, name,
+        ):
             _LOGGER.error("Failed to write recipe name")
+            return False
+
+        await asyncio.sleep(0.2)
+
+        return await self._protocol.start_process(
+            self._write_ble, MachineProcess.PRODUCT,
+        )
+
+    async def brew_freestyle(
+        self,
+        name: str,
+        recipe_type: int,
+        component1: "RecipeComponent",
+        component2: "RecipeComponent",
+    ) -> bool:
+        """Brew a freestyle (custom) recipe."""
+        if not self.connected:
+            return False
+        if self._status and not self._status.is_ready:
+            _LOGGER.warning("Machine not ready: %s", self._status)
+            return False
+
+        from .const import TEMP_RECIPE_ID, FREESTYLE_NAME_ID
+
+        if not await self._protocol.write_recipe(
+            self._write_ble, TEMP_RECIPE_ID, recipe_type, 0,
+            component1, component2,
+        ):
+            _LOGGER.error("Failed to write freestyle recipe")
+            return False
+
+        await asyncio.sleep(0.2)
+
+        if not await self._protocol.write_alphanumeric(
+            self._write_ble, FREESTYLE_NAME_ID, name,
+        ):
+            _LOGGER.error("Failed to write freestyle name")
             return False
 
         await asyncio.sleep(0.2)

--- a/custom_components/melitta_barista/const.py
+++ b/custom_components/melitta_barista/const.py
@@ -195,6 +195,69 @@ RECIPE_NAMES: dict[int, str] = {
 # Freestyle / temp recipe constants
 TEMP_RECIPE_ID = 400
 FREESTYLE_NAME_ID = 401
+FREESTYLE_RECIPE_TYPE = 24  # RecipeType.FREESTYLE byte value
+
+
+class ComponentProcess(IntEnum):
+    """Process type within a recipe component (coffee, steam, water)."""
+    NONE = 0
+    COFFEE = 1
+    STEAM = 2
+    WATER = 3
+
+
+class DirectKeyCategory(IntEnum):
+    """DirectKey recipe categories per profile."""
+    ESPRESSO = 0
+    CAFE_CREME = 1
+    CAPPUCCINO = 2
+    LATTE_MACCHIATO = 3
+    MILK_FROTH = 4
+    MILK = 5
+    WATER = 6
+
+
+# DirectKey offset and multiplier
+DIRECTKEY_OFFSET = 302
+DIRECTKEY_PROFILE_MULTIPLIER = 10
+
+
+def get_directkey_id(profile_id: int, category: DirectKeyCategory) -> int:
+    """Calculate DirectKey recipe ID for a profile and category."""
+    return DIRECTKEY_OFFSET + profile_id * DIRECTKEY_PROFILE_MULTIPLIER + category
+
+
+# Map RecipeId -> DirectKeyCategory for profile-based brewing
+RECIPE_TO_DIRECTKEY: dict[int, DirectKeyCategory] = {
+    RecipeId.ESPRESSO: DirectKeyCategory.ESPRESSO,
+    RecipeId.RISTRETTO: DirectKeyCategory.ESPRESSO,
+    RecipeId.LUNGO: DirectKeyCategory.ESPRESSO,
+    RecipeId.ESPRESSO_DOPIO: DirectKeyCategory.ESPRESSO,
+    RecipeId.RISETTO_DOPIO: DirectKeyCategory.ESPRESSO,
+    RecipeId.CAFE_CREME: DirectKeyCategory.CAFE_CREME,
+    RecipeId.CAFE_CREME_DOPIO: DirectKeyCategory.CAFE_CREME,
+    RecipeId.AMERICANO: DirectKeyCategory.CAFE_CREME,
+    RecipeId.AMERICANO_EXTRA: DirectKeyCategory.CAFE_CREME,
+    RecipeId.LONG_BLACK: DirectKeyCategory.CAFE_CREME,
+    RecipeId.RED_EYE: DirectKeyCategory.CAFE_CREME,
+    RecipeId.BLACK_EYE: DirectKeyCategory.CAFE_CREME,
+    RecipeId.DEAD_EYE: DirectKeyCategory.CAFE_CREME,
+    RecipeId.CAPPUCCINO: DirectKeyCategory.CAPPUCCINO,
+    RecipeId.ESPR_MACCHIATO: DirectKeyCategory.LATTE_MACCHIATO,
+    RecipeId.CAFFE_LATTE: DirectKeyCategory.CAPPUCCINO,
+    RecipeId.CAFE_AU_LAIT: DirectKeyCategory.CAPPUCCINO,
+    RecipeId.FLAT_WHITE: DirectKeyCategory.CAPPUCCINO,
+    RecipeId.LATTE_MACCHIATO: DirectKeyCategory.LATTE_MACCHIATO,
+    RecipeId.LATTE_MACCHIATO_EXTRA: DirectKeyCategory.LATTE_MACCHIATO,
+    RecipeId.LATTE_MACCHIATO_TRIPLE: DirectKeyCategory.LATTE_MACCHIATO,
+    RecipeId.MILK: DirectKeyCategory.MILK,
+    RecipeId.MILK_FROTH: DirectKeyCategory.MILK_FROTH,
+    RecipeId.WATER: DirectKeyCategory.WATER,
+}
+
+# Profile names for select entity
+PROFILE_NAMES = {0: "My Coffee"}  # Profile 0 is default
+
 
 # User profile name IDs: 310, 320, ..., 380
 USER_NAME_IDS = {i: 310 + (i - 1) * 10 for i in range(1, 9)}

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -17,5 +17,5 @@
     "bleak-retry-connector>=3.0.0",
     "pycryptodome>=3.0.0"
   ],
-  "version": "0.6.6"
+  "version": "0.7.0"
 }

--- a/custom_components/melitta_barista/select.py
+++ b/custom_components/melitta_barista/select.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .ble_client import MelittaBleClient
-from .const import DOMAIN, RECIPE_NAMES, RecipeId, get_available_recipes
+from .const import DOMAIN, PROFILE_NAMES, RECIPE_NAMES, RecipeId, get_available_recipes, get_user_profile_count
 
 _LOGGER = logging.getLogger("melitta_barista")
 
@@ -33,6 +33,7 @@ async def async_setup_entry(
 
     async_add_entities([
         MelittaRecipeSelect(client, entry, name),
+        MelittaProfileSelect(client, entry, name),
     ])
 
 
@@ -90,4 +91,82 @@ class MelittaRecipeSelect(SelectEntity):
         """Select a recipe (does not brew — use the Brew button)."""
         self._selected = option
         self._client.selected_recipe = _NAME_TO_RECIPE.get(option)
+        self.async_write_ha_state()
+
+
+class MelittaProfileSelect(SelectEntity):
+    """Select the active user profile."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Profile"
+    _attr_icon = "mdi:account-circle"
+
+    def __init__(
+        self,
+        client: MelittaBleClient,
+        entry: ConfigEntry,
+        machine_name: str,
+    ) -> None:
+        self._client = client
+        self._entry = entry
+        self._machine_name = machine_name
+        profile_count = get_user_profile_count(client.machine_type)
+        # Build options: "My Coffee", "Profile 1", ..., "Profile N"
+        self._profile_options: list[str] = [PROFILE_NAMES[0]]
+        for i in range(1, profile_count + 1):
+            self._profile_options.append(f"Profile {i}")
+        self._attr_options = list(self._profile_options)
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._client.address}_profile_select"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._client.address)},
+            name=self._machine_name,
+            manufacturer="Melitta",
+            model=self._client.model_name,
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        idx = self._client.active_profile
+        if 0 <= idx < len(self._profile_options):
+            return self._profile_options[idx]
+        return self._profile_options[0]
+
+    @property
+    def available(self) -> bool:
+        return self._client.connected
+
+    async def async_added_to_hass(self) -> None:
+        self._client.add_connection_callback(self._on_connection_change)
+        # Try to read profile names from machine
+        if self._client.connected:
+            await self._refresh_profile_names()
+
+    async def _refresh_profile_names(self) -> None:
+        """Read profile names from the machine and update options."""
+        from .const import USER_NAME_IDS
+        for i in range(1, len(self._profile_options)):
+            if i in USER_NAME_IDS:
+                name = await self._client.read_alpha(USER_NAME_IDS[i])
+                if name:
+                    self._profile_options[i] = name
+        self._attr_options = list(self._profile_options)
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
+        self.async_write_ha_state()
+
+    async def async_select_option(self, option: str) -> None:
+        """Select the active profile."""
+        try:
+            idx = self._profile_options.index(option)
+        except ValueError:
+            idx = 0
+        self._client.active_profile = idx
+        _LOGGER.info("Active profile set to %d (%s)", idx, option)
         self.async_write_ha_state()

--- a/custom_components/melitta_barista/services.yaml
+++ b/custom_components/melitta_barista/services.yaml
@@ -1,0 +1,131 @@
+brew_freestyle:
+  name: Brew Freestyle
+  description: Brew a custom freestyle recipe with specified components.
+  fields:
+    entity_id:
+      name: Entity
+      description: The brew button entity of the machine.
+      required: true
+      selector:
+        entity:
+          domain: button
+    name:
+      name: Recipe Name
+      description: Display name for the custom recipe.
+      required: true
+      default: "Custom"
+      selector:
+        text:
+    process1:
+      name: Component 1 Process
+      description: "Process type: coffee, steam, water"
+      required: true
+      default: "coffee"
+      selector:
+        select:
+          options:
+            - "coffee"
+            - "steam"
+            - "water"
+    intensity1:
+      name: Component 1 Intensity
+      description: "Intensity: very_mild, mild, medium, strong, very_strong"
+      required: false
+      default: "medium"
+      selector:
+        select:
+          options:
+            - "very_mild"
+            - "mild"
+            - "medium"
+            - "strong"
+            - "very_strong"
+    portion1_ml:
+      name: Component 1 Portion (ml)
+      description: Portion size in ml (multiples of 5).
+      required: false
+      default: 40
+      selector:
+        number:
+          min: 5
+          max: 250
+          step: 5
+          unit_of_measurement: ml
+    temperature1:
+      name: Component 1 Temperature
+      description: "Temperature: cold, normal, high"
+      required: false
+      default: "normal"
+      selector:
+        select:
+          options:
+            - "cold"
+            - "normal"
+            - "high"
+    shots1:
+      name: Component 1 Shots
+      description: "Shots: none, one, two, three"
+      required: false
+      default: "one"
+      selector:
+        select:
+          options:
+            - "none"
+            - "one"
+            - "two"
+            - "three"
+    process2:
+      name: Component 2 Process
+      description: "Process type for second component: none, coffee, steam, water"
+      required: false
+      default: "none"
+      selector:
+        select:
+          options:
+            - "none"
+            - "coffee"
+            - "steam"
+            - "water"
+    intensity2:
+      name: Component 2 Intensity
+      required: false
+      default: "medium"
+      selector:
+        select:
+          options:
+            - "very_mild"
+            - "mild"
+            - "medium"
+            - "strong"
+            - "very_strong"
+    portion2_ml:
+      name: Component 2 Portion (ml)
+      required: false
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 250
+          step: 5
+          unit_of_measurement: ml
+    temperature2:
+      name: Component 2 Temperature
+      required: false
+      default: "normal"
+      selector:
+        select:
+          options:
+            - "cold"
+            - "normal"
+            - "high"
+    shots2:
+      name: Component 2 Shots
+      required: false
+      default: "none"
+      selector:
+        select:
+          options:
+            - "none"
+            - "one"
+            - "two"
+            - "three"

--- a/tests/test_profile_and_freestyle.py
+++ b/tests/test_profile_and_freestyle.py
@@ -1,0 +1,284 @@
+"""Tests for profile select and freestyle recipe features."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.melitta_barista.const import (
+    DOMAIN,
+    DirectKeyCategory,
+    MachineProcess,
+    RecipeId,
+    get_directkey_id,
+)
+from custom_components.melitta_barista.protocol import MachineStatus, RecipeComponent
+
+from . import MOCK_ADDRESS, MOCK_CONFIG_DATA
+
+
+def _mock_client(status=None, selected_recipe=None):
+    client = MagicMock()
+    client.address = MOCK_ADDRESS
+    client.connected = True
+    client.status = status or MachineStatus(process=MachineProcess.READY)
+    client.firmware_version = "1.0.0"
+    client.machine_type = None
+    client.model_name = "Melitta Barista"
+    client.selected_recipe = selected_recipe
+    client.active_profile = 0
+    client.set_ble_device = MagicMock()
+    client.add_status_callback = MagicMock()
+    client.add_connection_callback = MagicMock()
+    client.connect = AsyncMock(return_value=True)
+    client.disconnect = AsyncMock()
+    client.start_polling = MagicMock()
+    client.brew_recipe = AsyncMock(return_value=True)
+    client.brew_freestyle = AsyncMock(return_value=True)
+    client.read_alpha = AsyncMock(return_value=None)
+    return client
+
+
+@pytest.fixture
+def mock_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA,
+        unique_id="aabbccddeeff",
+    )
+
+
+async def _setup_integration(hass, mock_entry, client):
+    mock_entry.add_to_hass(hass)
+    with (
+        patch(
+            "custom_components.melitta_barista.MelittaBleClient",
+            return_value=client,
+        ),
+        patch(
+            "custom_components.melitta_barista.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ),
+        patch(
+            "custom_components.melitta_barista.bluetooth.async_register_callback",
+            return_value=lambda: None,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+
+# --- Profile Select Tests ---
+
+
+async def test_profile_select_created(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test profile select entity is created."""
+    client = _mock_client()
+    await _setup_integration(hass, mock_entry, client)
+
+    selects = hass.states.async_all("select")
+    profile_select = [s for s in selects if "profile" in s.entity_id]
+    assert len(profile_select) == 1
+
+
+async def test_profile_select_has_options(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test profile select has correct options."""
+    client = _mock_client()
+    await _setup_integration(hass, mock_entry, client)
+
+    profile_select = [
+        s for s in hass.states.async_all("select") if "profile" in s.entity_id
+    ][0]
+    options = profile_select.attributes.get("options", [])
+
+    assert "My Coffee" in options
+    assert len(options) >= 2  # At least default + 1 profile
+
+
+async def test_profile_select_default(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test profile select defaults to My Coffee."""
+    client = _mock_client()
+    await _setup_integration(hass, mock_entry, client)
+
+    profile_select = [
+        s for s in hass.states.async_all("select") if "profile" in s.entity_id
+    ][0]
+    assert profile_select.state == "My Coffee"
+
+
+async def test_profile_select_changes_active_profile(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test selecting a profile updates active_profile on client."""
+    client = _mock_client()
+    await _setup_integration(hass, mock_entry, client)
+
+    profile_select = [
+        s for s in hass.states.async_all("select") if "profile" in s.entity_id
+    ][0]
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": profile_select.entity_id, "option": "Profile 1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert client.active_profile == 1
+
+
+# --- DirectKey Calculation Tests ---
+
+
+class TestDirectKey:
+    """Test DirectKey ID calculations."""
+
+    def test_directkey_profile0_espresso(self):
+        assert get_directkey_id(0, DirectKeyCategory.ESPRESSO) == 302
+
+    def test_directkey_profile0_water(self):
+        assert get_directkey_id(0, DirectKeyCategory.WATER) == 308
+
+    def test_directkey_profile1_espresso(self):
+        assert get_directkey_id(1, DirectKeyCategory.ESPRESSO) == 312
+
+    def test_directkey_profile1_cappuccino(self):
+        assert get_directkey_id(1, DirectKeyCategory.CAPPUCCINO) == 314
+
+    def test_directkey_profile8_latte(self):
+        assert get_directkey_id(8, DirectKeyCategory.LATTE_MACCHIATO) == 385
+
+
+# --- Freestyle Service Tests ---
+
+
+async def test_freestyle_service_registered(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Test that brew_freestyle service is registered."""
+    client = _mock_client()
+    await _setup_integration(hass, mock_entry, client)
+
+    assert hass.services.has_service(DOMAIN, "brew_freestyle")
+
+
+# --- BLE Client Profile Brew Tests ---
+
+
+class TestBleClientProfileBrew:
+    """Test brew_recipe with profile selection."""
+
+    @pytest.mark.asyncio
+    async def test_brew_with_default_profile(self):
+        """Default profile (0) reads the standard recipe ID."""
+        from custom_components.melitta_barista.ble_client import MelittaBleClient
+
+        client = MelittaBleClient("AA:BB:CC:DD:EE:FF")
+        client._connected = True
+        client._client = MagicMock(is_connected=True)
+        client._status = MachineStatus(process=MachineProcess.READY)
+        client.active_profile = 0
+
+        mock_recipe = MagicMock()
+        mock_recipe.recipe_type = 0
+        mock_recipe.component1 = RecipeComponent()
+        mock_recipe.component2 = RecipeComponent()
+        client._protocol.read_recipe = AsyncMock(return_value=mock_recipe)
+        client._protocol.write_recipe = AsyncMock(return_value=True)
+        client._protocol.write_alphanumeric = AsyncMock(return_value=True)
+        client._protocol.start_process = AsyncMock(return_value=True)
+
+        result = await client.brew_recipe(RecipeId.ESPRESSO)
+        assert result is True
+        # Should read from standard recipe ID 200
+        client._protocol.read_recipe.assert_awaited_once_with(
+            client._write_ble, RecipeId.ESPRESSO
+        )
+
+    @pytest.mark.asyncio
+    async def test_brew_with_profile1(self):
+        """Profile 1 reads from DirectKey ID."""
+        from custom_components.melitta_barista.ble_client import MelittaBleClient
+
+        client = MelittaBleClient("AA:BB:CC:DD:EE:FF")
+        client._connected = True
+        client._client = MagicMock(is_connected=True)
+        client._status = MachineStatus(process=MachineProcess.READY)
+        client.active_profile = 1
+
+        mock_recipe = MagicMock()
+        mock_recipe.recipe_type = 0
+        mock_recipe.component1 = RecipeComponent()
+        mock_recipe.component2 = RecipeComponent()
+        client._protocol.read_recipe = AsyncMock(return_value=mock_recipe)
+        client._protocol.write_recipe = AsyncMock(return_value=True)
+        client._protocol.write_alphanumeric = AsyncMock(return_value=True)
+        client._protocol.start_process = AsyncMock(return_value=True)
+
+        result = await client.brew_recipe(RecipeId.ESPRESSO)
+        assert result is True
+        # DirectKey for profile 1, ESPRESSO category = 302 + 1*10 + 0 = 312
+        client._protocol.read_recipe.assert_awaited_once_with(
+            client._write_ble, 312
+        )
+
+
+class TestBleClientFreestyle:
+    """Test brew_freestyle method."""
+
+    @pytest.mark.asyncio
+    async def test_freestyle_not_connected(self):
+        from custom_components.melitta_barista.ble_client import MelittaBleClient
+
+        client = MelittaBleClient("AA:BB:CC:DD:EE:FF")
+        result = await client.brew_freestyle(
+            "Test", 24, RecipeComponent(), RecipeComponent()
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_freestyle_success(self):
+        from custom_components.melitta_barista.ble_client import MelittaBleClient
+
+        client = MelittaBleClient("AA:BB:CC:DD:EE:FF")
+        client._connected = True
+        client._client = MagicMock(is_connected=True)
+        client._status = MachineStatus(process=MachineProcess.READY)
+        client._protocol.write_recipe = AsyncMock(return_value=True)
+        client._protocol.write_alphanumeric = AsyncMock(return_value=True)
+        client._protocol.start_process = AsyncMock(return_value=True)
+
+        comp1 = RecipeComponent(process=1, shots=1, intensity=3, portion=8)
+        comp2 = RecipeComponent(process=2, shots=0, portion=20)
+
+        result = await client.brew_freestyle("My Drink", 24, comp1, comp2)
+        assert result is True
+        client._protocol.write_recipe.assert_awaited_once()
+        client._protocol.write_alphanumeric.assert_awaited_once_with(
+            client._write_ble, 401, "My Drink"
+        )
+        client._protocol.start_process.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_freestyle_not_ready(self):
+        from custom_components.melitta_barista.ble_client import MelittaBleClient
+
+        client = MelittaBleClient("AA:BB:CC:DD:EE:FF")
+        client._connected = True
+        client._client = MagicMock(is_connected=True)
+        client._status = MachineStatus(process=MachineProcess.PRODUCT)
+
+        result = await client.brew_freestyle(
+            "Test", 24, RecipeComponent(), RecipeComponent()
+        )
+        assert result is False


### PR DESCRIPTION
## Summary
- Add **MelittaProfileSelect** entity — user profile selection with DirectKey-based per-profile brewing
- Add **brew_freestyle** service — custom freestyle recipes via TEMP_RECIPE (ID 400)
- Add `services.yaml` for HA service UI integration
- Add DirectKeyCategory enum and `get_directkey_id()` for per-profile recipe IDs
- 15 new tests covering profiles, DirectKey calculations, and freestyle brewing
- Version bump to **0.7.0**

## Test plan
- [x] All 123 tests passing
- [ ] Verify profile select entity appears in HA UI
- [ ] Verify profile switching changes brew behavior
- [ ] Verify brew_freestyle service appears in Developer Tools > Services
- [ ] Test freestyle brew with different component configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)