### PR TITLE
feat: freestyle recipe entities for HA UI

### DIFF
--- a/custom_components/melitta_barista/__init__.py
+++ b/custom_components/melitta_barista/__init__.py
@@ -64,7 +64,7 @@ def _async_cleanup_legacy_recipe_buttons(
         if (
             ent.domain == "button"
             and "_brew_" in (ent.unique_id or "")
-            and ent.unique_id != f"{address}_brew"
+            and ent.unique_id not in (f"{address}_brew", f"{address}_brew_freestyle")
         ):
             registry.async_remove(ent.entity_id)
             removed += 1

--- a/custom_components/melitta_barista/__init__.py
+++ b/custom_components/melitta_barista/__init__.py
@@ -172,7 +172,7 @@ async def _async_connect_and_poll(client: MelittaBleClient) -> None:
 
 SERVICE_BREW_FREESTYLE = "brew_freestyle"
 
-_PROCESS_MAP = {"none": 0, "coffee": 1, "steam": 2, "water": 3}
+_PROCESS_MAP = {"none": 0, "coffee": 1, "milk": 2, "water": 3}
 _INTENSITY_MAP = {"very_mild": 0, "mild": 1, "medium": 2, "strong": 3, "very_strong": 4}
 _TEMPERATURE_MAP = {"cold": 0, "normal": 1, "high": 2}
 _SHOTS_MAP = {"none": 0, "one": 1, "two": 2, "three": 3}

--- a/custom_components/melitta_barista/ble_client.py
+++ b/custom_components/melitta_barista/ble_client.py
@@ -72,6 +72,19 @@ class MelittaBleClient:
         self.selected_recipe: RecipeId | None = None
         self.active_profile: int = 0  # 0 = default "My Coffee"
 
+        # Freestyle recipe state (used by freestyle entities)
+        self.freestyle_name: str = "Custom"
+        self.freestyle_process1: str = "coffee"
+        self.freestyle_intensity1: str = "medium"
+        self.freestyle_portion1_ml: int = 40
+        self.freestyle_temperature1: str = "normal"
+        self.freestyle_shots1: str = "one"
+        self.freestyle_process2: str = "none"
+        self.freestyle_intensity2: str = "medium"
+        self.freestyle_portion2_ml: int = 0
+        self.freestyle_temperature2: str = "normal"
+        self.freestyle_shots2: str = "none"
+
         # Pre-detect machine type from BLE device name if available
         if device_name:
             self._machine_type = detect_machine_type_from_name(device_name)

--- a/custom_components/melitta_barista/button.py
+++ b/custom_components/melitta_barista/button.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .ble_client import MelittaBleClient
-from .const import DOMAIN, RECIPE_NAMES, MachineProcess
+from .const import DOMAIN, FREESTYLE_RECIPE_TYPE, RECIPE_NAMES, MachineProcess
 
 _LOGGER = logging.getLogger("melitta_barista")
 
@@ -30,6 +30,9 @@ async def async_setup_entry(
 
     # Brew button (works with Recipe select entity)
     entities.append(MelittaBrewButton(client, entry, name))
+
+    # Brew Freestyle button
+    entities.append(MelittaBrewFreestyleButton(client, entry, name))
 
     # Cancel button
     entities.append(MelittaCancelButton(client, entry, name))
@@ -117,6 +120,64 @@ class MelittaBrewButton(_MelittaButtonBase):
         success = await self._client.brew_recipe(recipe_id)
         if not success:
             _LOGGER.error("Failed to start brewing %s", recipe_name)
+
+
+_PROCESS_MAP = {"none": 0, "coffee": 1, "steam": 2, "water": 3}
+_INTENSITY_MAP = {"very_mild": 0, "mild": 1, "medium": 2, "strong": 3, "very_strong": 4}
+_TEMPERATURE_MAP = {"cold": 0, "normal": 1, "high": 2}
+_SHOTS_MAP = {"none": 0, "one": 1, "two": 2, "three": 3}
+
+
+class MelittaBrewFreestyleButton(_MelittaButtonBase):
+    """Button to brew a freestyle recipe using current freestyle entity values."""
+
+    _attr_name = "Brew Freestyle"
+    _attr_icon = "mdi:coffee-maker-outline"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._client.address}_brew_freestyle"
+
+    @property
+    def available(self) -> bool:
+        return (
+            self._client.connected
+            and self._client.status is not None
+            and self._client.status.is_ready
+        )
+
+    async def async_press(self) -> None:
+        from .protocol import RecipeComponent  # noqa: PLC0415
+
+        c = self._client
+        comp1 = RecipeComponent(
+            process=_PROCESS_MAP.get(c.freestyle_process1, 1),
+            shots=_SHOTS_MAP.get(c.freestyle_shots1, 1),
+            blend=1,
+            intensity=_INTENSITY_MAP.get(c.freestyle_intensity1, 2),
+            aroma=0,
+            temperature=_TEMPERATURE_MAP.get(c.freestyle_temperature1, 1),
+            portion=c.freestyle_portion1_ml // 5,
+        )
+        comp2 = RecipeComponent(
+            process=_PROCESS_MAP.get(c.freestyle_process2, 0),
+            shots=_SHOTS_MAP.get(c.freestyle_shots2, 0),
+            blend=0,
+            intensity=_INTENSITY_MAP.get(c.freestyle_intensity2, 2),
+            aroma=0,
+            temperature=_TEMPERATURE_MAP.get(c.freestyle_temperature2, 1),
+            portion=c.freestyle_portion2_ml // 5,
+        )
+
+        _LOGGER.info("Brewing freestyle: %s", c.freestyle_name)
+        success = await c.brew_freestyle(
+            name=c.freestyle_name,
+            recipe_type=FREESTYLE_RECIPE_TYPE,
+            component1=comp1,
+            component2=comp2,
+        )
+        if not success:
+            _LOGGER.error("Failed to brew freestyle recipe")
 
 
 class MelittaCancelButton(_MelittaButtonBase):

--- a/custom_components/melitta_barista/button.py
+++ b/custom_components/melitta_barista/button.py
@@ -122,7 +122,7 @@ class MelittaBrewButton(_MelittaButtonBase):
             _LOGGER.error("Failed to start brewing %s", recipe_name)
 
 
-_PROCESS_MAP = {"none": 0, "coffee": 1, "steam": 2, "water": 3}
+_PROCESS_MAP = {"none": 0, "coffee": 1, "milk": 2, "water": 3}
 _INTENSITY_MAP = {"very_mild": 0, "mild": 1, "medium": 2, "strong": 3, "very_strong": 4}
 _TEMPERATURE_MAP = {"cold": 0, "normal": 1, "high": 2}
 _SHOTS_MAP = {"none": 0, "one": 1, "two": 2, "three": 3}

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -17,5 +17,5 @@
     "bleak-retry-connector>=3.0.0",
     "pycryptodome>=3.0.0"
   ],
-  "version": "0.7.0"
+  "version": "0.7.1"
 }

--- a/custom_components/melitta_barista/number.py
+++ b/custom_components/melitta_barista/number.py
@@ -65,6 +65,15 @@ async def async_setup_entry(
         MelittaSettingNumber(client, entry, name, defn)
         for defn in SETTING_DEFINITIONS
     ]
+    # Freestyle portion entities
+    entities.append(MelittaFreestyleNumber(
+        client, entry, name, "portion_1", "Freestyle Portion 1",
+        "mdi:cup-water", 5, 250, 5, "freestyle_portion1_ml",
+    ))
+    entities.append(MelittaFreestyleNumber(
+        client, entry, name, "portion_2", "Freestyle Portion 2",
+        "mdi:cup-water", 0, 250, 5, "freestyle_portion2_ml",
+    ))
     async_add_entities(entities)
 
 
@@ -128,3 +137,67 @@ class MelittaSettingNumber(NumberEntity):
         if await self._client.write_setting(self._setting_id, int(value)):
             self._attr_native_value = value
             self.async_write_ha_state()
+
+
+class MelittaFreestyleNumber(NumberEntity):
+    """Number entity for a freestyle recipe portion parameter."""
+
+    _attr_has_entity_name = True
+    _attr_mode = NumberMode.BOX
+    _attr_native_unit_of_measurement = "ml"
+
+    def __init__(
+        self,
+        client: MelittaBleClient,
+        entry: ConfigEntry,
+        machine_name: str,
+        key: str,
+        label: str,
+        icon: str,
+        min_val: int,
+        max_val: int,
+        step: int,
+        client_attr: str,
+    ) -> None:
+        self._client = client
+        self._entry = entry
+        self._machine_name = machine_name
+        self._key = key
+        self._client_attr = client_attr
+        self._attr_name = label
+        self._attr_icon = icon
+        self._attr_native_min_value = min_val
+        self._attr_native_max_value = max_val
+        self._attr_native_step = step
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._client.address}_freestyle_{self._key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._client.address)},
+            name=self._machine_name,
+            manufacturer="Melitta",
+            model=self._client.model_name,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        return float(getattr(self._client, self._client_attr, 0))
+
+    @property
+    def available(self) -> bool:
+        return self._client.connected
+
+    async def async_added_to_hass(self) -> None:
+        self._client.add_connection_callback(self._on_connection_change)
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
+        self.async_write_ha_state()
+
+    async def async_set_native_value(self, value: float) -> None:
+        setattr(self._client, self._client_attr, int(value))
+        self.async_write_ha_state()

--- a/custom_components/melitta_barista/select.py
+++ b/custom_components/melitta_barista/select.py
@@ -15,8 +15,8 @@ from .ble_client import MelittaBleClient
 from .const import DOMAIN, PROFILE_NAMES, RECIPE_NAMES, RecipeId, get_available_recipes, get_user_profile_count
 
 # Freestyle option lists
-_PROCESS_OPTIONS = ["coffee", "steam", "water"]
-_PROCESS_OPTIONS_WITH_NONE = ["none", "coffee", "steam", "water"]
+_PROCESS_OPTIONS = ["coffee", "milk", "water"]
+_PROCESS_OPTIONS_WITH_NONE = ["none", "coffee", "milk", "water"]
 _INTENSITY_OPTIONS = ["very_mild", "mild", "medium", "strong", "very_strong"]
 _TEMPERATURE_OPTIONS = ["cold", "normal", "high"]
 _SHOTS_OPTIONS = ["none", "one", "two", "three"]

--- a/custom_components/melitta_barista/select.py
+++ b/custom_components/melitta_barista/select.py
@@ -14,6 +14,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .ble_client import MelittaBleClient
 from .const import DOMAIN, PROFILE_NAMES, RECIPE_NAMES, RecipeId, get_available_recipes, get_user_profile_count
 
+# Freestyle option lists
+_PROCESS_OPTIONS = ["coffee", "steam", "water"]
+_PROCESS_OPTIONS_WITH_NONE = ["none", "coffee", "steam", "water"]
+_INTENSITY_OPTIONS = ["very_mild", "mild", "medium", "strong", "very_strong"]
+_TEMPERATURE_OPTIONS = ["cold", "normal", "high"]
+_SHOTS_OPTIONS = ["none", "one", "two", "three"]
+
 _LOGGER = logging.getLogger("melitta_barista")
 
 # Reverse lookup: name -> RecipeId
@@ -34,6 +41,15 @@ async def async_setup_entry(
     async_add_entities([
         MelittaRecipeSelect(client, entry, name),
         MelittaProfileSelect(client, entry, name),
+        # Freestyle parameter selects
+        MelittaFreestyleSelect(client, entry, name, "process_1", "Process 1", "mdi:coffee", _PROCESS_OPTIONS, "freestyle_process1"),
+        MelittaFreestyleSelect(client, entry, name, "intensity_1", "Intensity 1", "mdi:gauge", _INTENSITY_OPTIONS, "freestyle_intensity1"),
+        MelittaFreestyleSelect(client, entry, name, "temperature_1", "Temperature 1", "mdi:thermometer", _TEMPERATURE_OPTIONS, "freestyle_temperature1"),
+        MelittaFreestyleSelect(client, entry, name, "shots_1", "Shots 1", "mdi:numeric", _SHOTS_OPTIONS, "freestyle_shots1"),
+        MelittaFreestyleSelect(client, entry, name, "process_2", "Process 2", "mdi:coffee-outline", _PROCESS_OPTIONS_WITH_NONE, "freestyle_process2"),
+        MelittaFreestyleSelect(client, entry, name, "intensity_2", "Intensity 2", "mdi:gauge", _INTENSITY_OPTIONS, "freestyle_intensity2"),
+        MelittaFreestyleSelect(client, entry, name, "temperature_2", "Temperature 2", "mdi:thermometer", _TEMPERATURE_OPTIONS, "freestyle_temperature2"),
+        MelittaFreestyleSelect(client, entry, name, "shots_2", "Shots 2", "mdi:numeric", _SHOTS_OPTIONS, "freestyle_shots2"),
     ])
 
 
@@ -169,4 +185,62 @@ class MelittaProfileSelect(SelectEntity):
             idx = 0
         self._client.active_profile = idx
         _LOGGER.info("Active profile set to %d (%s)", idx, option)
+        self.async_write_ha_state()
+
+
+class MelittaFreestyleSelect(SelectEntity):
+    """Select entity for a freestyle recipe parameter."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        client: MelittaBleClient,
+        entry: ConfigEntry,
+        machine_name: str,
+        key: str,
+        label: str,
+        icon: str,
+        options: list[str],
+        client_attr: str,
+    ) -> None:
+        self._client = client
+        self._entry = entry
+        self._machine_name = machine_name
+        self._key = key
+        self._client_attr = client_attr
+        self._attr_name = f"Freestyle {label}"
+        self._attr_icon = icon
+        self._attr_options = list(options)
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._client.address}_freestyle_{self._key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._client.address)},
+            name=self._machine_name,
+            manufacturer="Melitta",
+            model=self._client.model_name,
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        return getattr(self._client, self._client_attr, self._attr_options[0])
+
+    @property
+    def available(self) -> bool:
+        return self._client.connected
+
+    async def async_added_to_hass(self) -> None:
+        self._client.add_connection_callback(self._on_connection_change)
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
+        self.async_write_ha_state()
+
+    async def async_select_option(self, option: str) -> None:
+        setattr(self._client, self._client_attr, option)
         self.async_write_ha_state()

--- a/custom_components/melitta_barista/services.yaml
+++ b/custom_components/melitta_barista/services.yaml
@@ -18,14 +18,14 @@ brew_freestyle:
         text:
     process1:
       name: Component 1 Process
-      description: "Process type: coffee, steam, water"
+      description: "Process type: coffee, milk, water"
       required: true
       default: "coffee"
       selector:
         select:
           options:
             - "coffee"
-            - "steam"
+            - "milk"
             - "water"
     intensity1:
       name: Component 1 Intensity
@@ -76,7 +76,7 @@ brew_freestyle:
             - "three"
     process2:
       name: Component 2 Process
-      description: "Process type for second component: none, coffee, steam, water"
+      description: "Process type for second component: none, coffee, milk, water"
       required: false
       default: "none"
       selector:
@@ -84,7 +84,7 @@ brew_freestyle:
           options:
             - "none"
             - "coffee"
-            - "steam"
+            - "milk"
             - "water"
     intensity2:
       name: Component 2 Intensity

--- a/custom_components/melitta_barista/text.py
+++ b/custom_components/melitta_barista/text.py
@@ -32,6 +32,7 @@ async def async_setup_entry(
         MelittaProfileNameText(client, entry, name, profile_num)
         for profile_num in range(1, profile_count + 1)
     ]
+    entities.append(MelittaFreestyleNameText(client, entry, name))
     async_add_entities(entities)
 
 
@@ -91,3 +92,54 @@ class MelittaProfileNameText(TextEntity):
         if await self._client.write_alpha(self._name_id, value):
             self._attr_native_value = value
             self.async_write_ha_state()
+
+
+class MelittaFreestyleNameText(TextEntity):
+    """Text entity for the freestyle recipe name."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Freestyle Name"
+    _attr_icon = "mdi:label-outline"
+    _attr_native_max = 30
+
+    def __init__(
+        self,
+        client: MelittaBleClient,
+        entry: ConfigEntry,
+        machine_name: str,
+    ) -> None:
+        self._client = client
+        self._entry = entry
+        self._machine_name = machine_name
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._client.address}_freestyle_name"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._client.address)},
+            name=self._machine_name,
+            manufacturer="Melitta",
+            model=self._client.model_name,
+        )
+
+    @property
+    def native_value(self) -> str | None:
+        return self._client.freestyle_name
+
+    @property
+    def available(self) -> bool:
+        return self._client.connected
+
+    async def async_added_to_hass(self) -> None:
+        self._client.add_connection_callback(self._on_connection_change)
+
+    @callback
+    def _on_connection_change(self, connected: bool) -> None:
+        self.async_write_ha_state()
+
+    async def async_set_value(self, value: str) -> None:
+        self._client.freestyle_name = value
+        self.async_write_ha_state()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -25,6 +25,18 @@ def _mock_client():
     client.machine_type = None
     client.model_name = "Melitta Barista"
     client.selected_recipe = None
+    client.active_profile = 0
+    client.freestyle_name = "Custom"
+    client.freestyle_process1 = "coffee"
+    client.freestyle_intensity1 = "medium"
+    client.freestyle_portion1_ml = 40
+    client.freestyle_temperature1 = "normal"
+    client.freestyle_shots1 = "one"
+    client.freestyle_process2 = "none"
+    client.freestyle_intensity2 = "medium"
+    client.freestyle_portion2_ml = 0
+    client.freestyle_temperature2 = "normal"
+    client.freestyle_shots2 = "none"
     client.set_ble_device = MagicMock()
     client.add_status_callback = MagicMock()
     client.add_connection_callback = MagicMock()
@@ -175,6 +187,6 @@ async def test_legacy_cleanup_removes_named_entities(
 
     remaining = [
         e for e in er.async_entries_for_config_entry(registry, mock_entry.entry_id)
-        if "_brew_" in e.unique_id
+        if "_brew_" in e.unique_id and "_brew_freestyle" not in e.unique_id
     ]
     assert len(remaining) == 0

--- a/tests/test_profile_and_freestyle.py
+++ b/tests/test_profile_and_freestyle.py
@@ -30,6 +30,17 @@ def _mock_client(status=None, selected_recipe=None):
     client.model_name = "Melitta Barista"
     client.selected_recipe = selected_recipe
     client.active_profile = 0
+    client.freestyle_name = "Custom"
+    client.freestyle_process1 = "coffee"
+    client.freestyle_intensity1 = "medium"
+    client.freestyle_portion1_ml = 40
+    client.freestyle_temperature1 = "normal"
+    client.freestyle_shots1 = "one"
+    client.freestyle_process2 = "none"
+    client.freestyle_intensity2 = "medium"
+    client.freestyle_portion2_ml = 0
+    client.freestyle_temperature2 = "normal"
+    client.freestyle_shots2 = "none"
     client.set_ble_device = MagicMock()
     client.add_status_callback = MagicMock()
     client.add_connection_callback = MagicMock()


### PR DESCRIPTION
## Summary
- Add **11 freestyle entities** that appear in standard HA UI:
  - 8 select entities: Process/Intensity/Temperature/Shots for Component 1 and 2
  - 2 number entities: Portion 1 and Portion 2 (in ml)
  - 1 text entity: Freestyle Name
- Add **Brew Freestyle** button that reads current entity values and brews
- Fix legacy entity cleanup to preserve the new `brew_freestyle` button
- Version bump to **0.7.1**

## Test plan
- [x] All 123 tests passing
- [ ] Verify freestyle entities appear in HA device page
- [ ] Verify changing entity values updates freestyle parameters
- [ ] Verify Brew Freestyle button triggers brew with correct parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)