### PR TITLE
fix: Nivona advertisement regex + D-Bus fallback (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
+## [0.76.0] — 2026-05-27
+
+### Fixed
+- **Nivona advertisement regex is now permissive about digit-count and dash-count** (#15). Every new Nivona model series has revealed a new advertisement shape — NIVO 8107 / NICR 6xx-7xx use 10 digits + 5 dashes, NICR 930 uses 15 digits with no dashes, NICR 779 (#14) uses 15 digits + 5 dashes, and NIVO 8001 (#15) uses 17 digits + 3 dashes. The `ble_name_regex` previously enumerated these combinations individually and required a follow-up patch for each new model; it now accepts any `\d{10,}` serial with optional trailing dashes (and optional `NIVONA-` prefix). Brand discrimination from Melitta is unaffected because Melitta's tighter 6-prefix regex is still matched first.
+- **D-Bus connect failure in `ble_agent` now falls through to "skip pairing" instead of being reported as a pairing failure** (#15). When the system D-Bus is unreachable (typical for HA OS containers without a host BlueZ stack — the device is reached via ESPHome BLE proxy that handles bonding at the ESP32 level), the integration used to bubble the `MessageBus.connect()` exception up as `pairing_failed`. It now treats this case the same as a missing `Adapter1` interface — `async_pair_device` returns `"ok"` with an info-log, and pairing succeeds against the proxy.
+
+### Notes
+- `_PREFIX_TO_FAMILY` still mirrors the official Nivona app's `ToCoffeeMachineModel` table exactly (`8101`/`8103`/`8107` → `8000`). The reporter of #15 advertised a serial starting with `81…` (17 digits + 3 dashes), but the full prefix is obfuscated and the decompiled APK v3.8.6 doesn't know any other 81xx variant either. Discovery and pairing now succeed thanks to the permissive regex; if the resulting family ends up `None`, surface the issue and add the prefix once the reporter shares the first 4 serial digits — we'd rather show "unknown model" than guess capabilities wrongly.
+
 ## [0.75.0] — 2026-05-27
 
 ### Added (panel)

--- a/custom_components/melitta_barista/ble_agent.py
+++ b/custom_components/melitta_barista/ble_agent.py
@@ -196,7 +196,20 @@ async def async_pair_device(address: str, timeout: float = 30.0) -> str:
     adapter = None
 
     try:
-        bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+        try:
+            bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+        except Exception:  # noqa: BLE001 — dbus_fast raises many shapes
+            # No reachable system D-Bus (typical in HA OS containers
+            # without a host BlueZ stack). Functionally equivalent to
+            # "no Adapter1" — the device is reached via an ESPHome BLE
+            # proxy that handles bonding at the ESP32 level. Reported
+            # in #15.
+            _LOGGER.info(
+                "System D-Bus not reachable. "
+                "Assuming ESPHome BLE proxy — skipping D-Bus pairing for %s",
+                address,
+            )
+            return "ok"
 
         adapter = await _get_adapter(bus)
         if adapter is None:

--- a/custom_components/melitta_barista/brands/nivona.py
+++ b/custom_components/melitta_barista/brands/nivona.py
@@ -969,7 +969,12 @@ _NIVONA_FAMILIES: dict[str, MachineCapabilities] = {
 # Serial-prefix → family. Exhaustive 4-char then 3-char cascade matches
 # the upstream `detectModelInfo` cascade.
 _PREFIX_TO_FAMILY: dict[str, str] = {
-    # 4-char (NIVO 8xxx serials)
+    # 4-char (NIVO 8xxx serials). Mirrors the official Nivona app's
+    # `ToCoffeeMachineModel(string serial)` table exactly (decompiled
+    # APK v3.8.6) — only 8101/8103/8107 are known model codes in the
+    # 8000 family. Newer 81xx variants reported in the field (#15) are
+    # left to fall through to "unknown family"; we'd rather surface
+    # that honestly than guess.
     "8101": "8000", "8103": "8000", "8107": "8000",
     # 3-char (NICR series; matched after 4-char miss)
     "660": "600", "670": "600", "675": "600", "680": "600",
@@ -997,20 +1002,22 @@ class NivonaProfile:
     service_uuid: ClassVar[str] = "0000ad00-b35c-11e4-9813-0002a5d5c51b"
     handshake_response_size: ClassVar[int] = 8
 
-    # Nivona advertisement: 10-digit serial + exactly 5 trailing dashes
-    # (e.g. "8107000001-----"). Some older captures show an optional
-    # "NIVONA-" prefix, but real machines advertise bare-serial form so
-    # the official Android app can derive the model code via
-    # Substring(0, 4) — keeping the "NIVONA-" prefix would make it
-    # resolve to "NIVO" and no family would match (see EugsterMobileApp
-    # name-filter logic). The 5-dash suffix is the distinguisher from
-    # Melitta's ``8xxx + hex`` advertisement format.
-    # Some Nivona models (e.g. NICR 779, reported in #14) advertise as a
-    # 15-digit serial *with* the 5-dash trailing suffix, not just a bare
-    # 15-digit form. Allow 10..15 digits + 5 dashes alongside the
-    # original 15-digit-no-dashes branch.
+    # Nivona advertisement: a numeric serial (optionally prefixed with
+    # "NIVONA-") followed by zero or more trailing dashes. We no longer
+    # enumerate exact digit/dash counts — every new model series has
+    # revealed a new combination:
+    #   - NIVO 8107 / NICR 6xx-7xx: 10 digits + 5 dashes
+    #   - NICR 930: 15 digits, no dashes
+    #   - NICR 779 (#14): 15 digits + 5 dashes
+    #   - NIVO 8001 (#15): 17 digits + 3 dashes
+    # Brand discrimination from Melitta still works because Melitta's
+    # regex is matched FIRST and requires one of 6 specific hex-digit
+    # prefixes followed by hex characters — anything pure-numeric (with
+    # optional dashes) that doesn't match Melitta falls through to
+    # Nivona. Family/model identification happens separately via
+    # `detect_family()` against `_PREFIX_TO_FAMILY`.
     ble_name_regex: ClassVar[re.Pattern[str]] = re.compile(
-        r"^(?:NIVONA-)?(?:\d{15}|\d{10,15}-----)$"
+        r"^(?:NIVONA-)?\d{10,}-*$"
     )
 
     # Nivona machines do not expose recipe read/write commands.

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -31,5 +31,5 @@
     "aiosqlite>=0.19.0",
     "pydantic>=2.0"
   ],
-  "version": "0.75.0"
+  "version": "0.76.0"
 }

--- a/tests/test_ble_agent.py
+++ b/tests/test_ble_agent.py
@@ -416,8 +416,13 @@ class TestAsyncPairDevice:
         assert result == "pairing_failed"
 
     @pytest.mark.asyncio
-    async def test_dbus_connection_error_returns_pairing_failed(self) -> None:
-        """When D-Bus connection itself fails, returns 'pairing_failed'."""
+    async def test_dbus_connection_error_skips_pairing(self) -> None:
+        """When the system D-Bus is unreachable (no local BlueZ stack —
+        typical for HA OS supervised installs that rely on an ESPHome
+        BLE proxy), pairing is skipped rather than reported as a
+        pairing failure. The proxy handles BLE bonding at the ESP32
+        level, so a missing D-Bus is functionally equivalent to a
+        missing Adapter1. Reported in #15."""
         mod = _import_ble_agent()
 
         constructor = MagicMock()
@@ -428,7 +433,7 @@ class TestAsyncPairDevice:
         with patch.object(mod, "MessageBus", constructor):
             result = await mod.async_pair_device(MOCK_ADDRESS, timeout=5.0)
 
-        assert result == "pairing_failed"
+        assert result == "ok"
 
     @pytest.mark.asyncio
     async def test_device_not_known_starts_discovery(self) -> None:

--- a/tests/test_brands.py
+++ b/tests/test_brands.py
@@ -90,18 +90,28 @@ def test_advertisement_matches_nivona_pattern():
     assert profile is not None and profile.brand_slug == "nivona"
     # Detected family should be "700" since 779 prefix routes there.
     assert profile.detect_family("779573191222251-----") == "700"
+    # 17-digit + 3-dash form — observed on NIVO 8001 in #15. The regex
+    # used to enumerate digit-counts; the new permissive contract is
+    # "any digit-string + optional trailing dashes".
+    profile = detect_from_advertisement("80010000000000000---")
+    assert profile is not None and profile.brand_slug == "nivona"
 
 
 def test_advertisement_no_match():
     assert detect_from_advertisement("Random Device") is None
     assert detect_from_advertisement("") is None
     assert detect_from_advertisement(None) is None
-    # Purely numeric names that should NOT match Nivona
-    assert detect_from_advertisement("1234567890") is None       # 10 digits, no dashes
-    assert detect_from_advertisement("12345678901234") is None   # 14 digits
-    # Sixteen digits + 5 dashes — must NOT be treated as Nivona (the
-    # 10..15-digit range is the intentional contract from #14).
-    assert detect_from_advertisement("7795731912222515-----") is None
+    # Too short to be a serial — must NOT match Nivona.
+    assert detect_from_advertisement("123456789") is None         # 9 digits
+    # Letters anywhere disqualify Nivona (Melitta uses hex prefixes
+    # already excluded by Melitta's stricter regex).
+    assert detect_from_advertisement("ABCDEFGH--") is None
+    # Note: as of #15 the Nivona regex is intentionally permissive
+    # about digit-count and dash-count — every new Nivona model
+    # series (NICR 779 in #14, NIVO 8001 in #15) revealed a new
+    # combination, so anything shaped like "10+ digits and optional
+    # trailing dashes" now resolves to Nivona. Melitta is still
+    # matched first via its tight 6-prefix regex.
 
 
 # ---------------------------------------------------------------------------
@@ -178,6 +188,12 @@ def test_nivona_detect_family_from_serial():
     assert np_.detect_family("NIVONA-7565730710-----") == "700"
     # NIVO 8101 → family 8000 (via 4-char prefix "8101")
     assert np_.detect_family("NIVONA-8101000000-----") == "8000"
+    # 81xx serial with an unknown 4-char prefix returns None: we mirror
+    # the official APK table (8101/8103/8107) exactly, so a hypothetical
+    # 8108 serial falls through to "unknown family" rather than being
+    # guessed into the 8000 bucket. Discovery still succeeds via the
+    # permissive regex, the user just sees an "unknown model" entry.
+    assert np_.detect_family("81080000000000000---") is None
     # NICR 660 → family 600
     assert np_.detect_family("NIVONA-6605730710-----") == "600"
     # Unknown serial


### PR DESCRIPTION
## Summary

Closes #15.

- **Permissive Nivona regex** (`^(?:NIVONA-)?\d{10,}-*$`) — every new Nivona advertisement shape (10+5, 15+0, 15+5, **17+3**, ...) is accepted without further regex extension on every new model. Melitta's stricter 6-prefix regex is matched first, so brand discrimination is unaffected.
- **D-Bus fallback in `ble_agent`** — when `MessageBus(BusType.SYSTEM).connect()` fails (HA OS containers without a host BlueZ stack — typical for ESPHome BLE proxy installs), `async_pair_device` now returns `ok` and skips D-Bus pairing, instead of bubbling the exception as `pairing_failed`. Functionally equivalent to the pre-existing "no `Adapter1`" branch.
- **`_PREFIX_TO_FAMILY` unchanged** — keeps the known 8000-family model codes (`8101` / `8103` / `8107` → `8000`). The #15 reporter has since confirmed `NIVO 8001` was a typo in the title; the real model is NIVO 8101, already supported.

Bumps `manifest.json` to **0.76.0**.

## Test plan

- [x] `pytest tests/` — 952 passed
- [x] `tests/test_brands.py::test_advertisement_matches_nivona_pattern` — new positive case for 17+3 form
- [x] `tests/test_ble_agent.py::test_dbus_connection_error_skips_pairing` — inverted contract
- [ ] Field validation by #15 reporter on real NIVO 8101 hardware after 0.76.0 ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)