### PR TITLE
fix: validate HU handshake response end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
+## [0.76.1] — 2026-05-28
+
+### Fixed
+- **HU handshake response is now fully validated** end-to-end (Gap #1 in `docs/PROTOCOL_VERIFICATION.md`). The response handler now requires the response to be ≥ 8 bytes, verifies that `payload[0:4]` echoes the random seed we sent, and recomputes the HU verifier over `payload[0:6]` to check `payload[6:8]`. Any mismatch is logged at WARNING and rejected — `_key_prefix` stays `None` and `_handshake_done` is set so `perform_handshake` returns `False` immediately instead of hanging until the frame-timeout. Previously the handler trusted whatever the machine sent: a corrupted / mismatched response would install a junk session key, and every subsequent RC4-encrypted frame would fail to decrypt with no obvious error. Mirrors the upstream `parseHuResponsePayload` from `esp-coffee-bridge/src/nivona.cpp`.
+
+### Tests
+- 4 new tests in `tests/test_protocol.py::TestHandshakeResponseVerification` (happy path, wrong echoed seed, wrong verifier, short response).
+- Existing `test_handshake_sends_challenge` pins `os.urandom` to a fixed seed so the test response can be crafted with the correct verifier; existing `test_handshake_response_too_short` updated for the new "event set on reject" contract.
+
 ## [0.76.0] — 2026-05-27
 
 ### Fixed

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -31,5 +31,5 @@
     "aiosqlite>=0.19.0",
     "pydantic>=2.0"
   ],
-  "version": "0.76.0"
+  "version": "0.76.1"
 }

--- a/custom_components/melitta_barista/protocol.py
+++ b/custom_components/melitta_barista/protocol.py
@@ -287,6 +287,13 @@ class EugsterProtocol:
 
         self._rc4_key: bytes | None = None
         self._key_prefix: bytes | None = None
+        # Stored across the request/response of a single HU handshake so
+        # the response handler can verify the echoed seed. Cleared on
+        # entry to `perform_handshake`, set after the challenge is
+        # generated, and remains set after handshake completes — that
+        # way a duplicate / late HU notify is still bound to the right
+        # challenge.
+        self._pending_challenge: bytes | None = None
         self._recv_buffer = bytearray()
         self._frame_start_time: float = 0.0
         self._frame_futures: dict[str, asyncio.Future] = {}
@@ -550,12 +557,60 @@ class EugsterProtocol:
                 future.set_result(payload)
 
     def _handle_handshake_response(self, payload: bytes) -> None:
-        """Process HU handshake response: challenge(4) + key_prefix(2) + validation(2)."""
-        if len(payload) < 6:
-            _LOGGER.error("HU response too short: %d bytes", len(payload))
+        """Process HU handshake response and validate it end-to-end.
+
+        Wire layout (8 bytes, post-RC4-decrypt):
+            payload[0:4]  echoed seed — must equal the challenge we sent
+            payload[4:6]  session_key (key_prefix in our terminology)
+            payload[6:8]  verifier — must equal hu_verifier(payload[0:6])
+
+        On any mismatch the method records the failure, leaves
+        ``_key_prefix`` as ``None`` and still sets ``_handshake_done`` so
+        ``perform_handshake`` returns ``False`` instead of hanging. This
+        mirrors upstream ``parseHuResponsePayload`` (esp-coffee-bridge
+        ``src/nivona.cpp``) — without these checks an invalid response
+        would silently install a junk session key and every subsequent
+        RC4-encrypted frame would be undecryptable.
+        """
+        # Length gate. Upstream demands exactly 8; we accept >= 8 to
+        # tolerate a hypothetical trailing-byte firmware variant, then
+        # only consume the first 8.
+        if len(payload) < 8:
+            _LOGGER.warning(
+                "HU response too short: %d bytes (need >= 8); rejecting",
+                len(payload),
+            )
+            self._handshake_done.set()
             return
 
+        echoed_seed = payload[0:4]
         key_prefix = payload[4:6]
+        response_verifier = payload[6:8]
+
+        if self._pending_challenge is None:
+            _LOGGER.warning(
+                "HU response received without a pending challenge; rejecting"
+            )
+            self._handshake_done.set()
+            return
+
+        if echoed_seed != self._pending_challenge:
+            _LOGGER.warning(
+                "HU echoed seed mismatch: sent %s, got %s; rejecting",
+                self._pending_challenge.hex(), echoed_seed.hex(),
+            )
+            self._handshake_done.set()
+            return
+
+        expected_verifier = self._brand.hu_verifier(payload, 0, 6)
+        if response_verifier != expected_verifier:
+            _LOGGER.warning(
+                "HU verifier mismatch: expected %s, got %s; rejecting",
+                expected_verifier.hex(), response_verifier.hex(),
+            )
+            self._handshake_done.set()
+            return
+
         self._key_prefix = key_prefix
         self._handshake_done.set()
         _LOGGER.info("Handshake complete, key_prefix=%s", key_prefix.hex())
@@ -570,10 +625,13 @@ class EugsterProtocol:
         """Perform HU challenge-response handshake."""
         self._handshake_done.clear()
         self._key_prefix = None
+        self._pending_challenge = None
 
         challenge = os.urandom(4)
         verifier = self._brand.hu_verifier(challenge, 0, len(challenge))
         hu_payload = challenge + verifier  # 6 bytes
+        # Stored BEFORE we write — the response is verified against it.
+        self._pending_challenge = challenge
 
         frame = self.build_frame(CMD_HANDSHAKE, hu_payload, include_key_prefix=False)
         chunks = self.chunk_for_ble(frame)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -10,6 +10,7 @@ from custom_components.melitta_barista.const import (
 )
 from custom_components.melitta_barista.protocol import (
     KNOWN_COMMANDS,
+    EugsterProtocol,
     MachineRecipe,
     MachineStatus,
     NumericalValue,
@@ -19,6 +20,7 @@ from custom_components.melitta_barista.protocol import (
     _rc4_crypt,
 )
 from custom_components.melitta_barista.brands.melitta import MelittaProfile
+from custom_components.melitta_barista.brands.nivona import NivonaProfile
 
 
 class TestRC4:
@@ -349,3 +351,79 @@ class TestStartProcessNivonaPayload:
         """Chilled NICR 8107 selectors always use 0x00 even if temp set."""
         p = self._build_payload(use_temp_recipe=True, chilled=True)
         assert p[5] == 0x00
+
+
+class TestHandshakeResponseVerification:
+    """HU response validation per upstream `parseHuResponsePayload`.
+
+    Wire layout (8 bytes after RC4 decrypt):
+        [0..4)  echoed seed — must equal the challenge we sent
+        [4..6)  session_key (key_prefix in our terminology)
+        [6..8)  verifier — must equal hu_verifier(payload[0..6])
+    """
+
+    def _make_proto(self) -> EugsterProtocol:
+        # Nivona has a non-trivial HU table; that's what's at risk if
+        # a wrong-brand machine responded. Using Nivona forces real
+        # verifier computation.
+        return EugsterProtocol(brand=NivonaProfile())
+
+    def test_valid_response_sets_key_prefix(self):
+        proto = self._make_proto()
+        challenge = bytes.fromhex("01020304")
+        proto._pending_challenge = challenge
+        key_prefix = b"\xAB\xCD"
+        body = challenge + key_prefix  # 6 bytes
+        verifier = proto._brand.hu_verifier(body, 0, len(body))
+        payload = body + verifier  # 8 bytes total
+
+        proto._handle_handshake_response(payload)
+
+        assert proto._key_prefix == key_prefix
+        assert proto._handshake_done.is_set()
+
+    def test_wrong_echoed_seed_rejects(self):
+        """Machine echoes a different seed than we sent — reject."""
+        proto = self._make_proto()
+        proto._pending_challenge = bytes.fromhex("01020304")
+        # Build a payload that's internally consistent but with
+        # a *different* echoed seed than the one we stored.
+        bad_seed = bytes.fromhex("FFFFFFFF")
+        key_prefix = b"\xAB\xCD"
+        body = bad_seed + key_prefix
+        verifier = proto._brand.hu_verifier(body, 0, len(body))
+        payload = body + verifier
+
+        proto._handle_handshake_response(payload)
+
+        assert proto._key_prefix is None, (
+            "Wrong echoed seed must reject the session key"
+        )
+        # Event must still be set so perform_handshake returns False
+        # (instead of hanging until timeout).
+        assert proto._handshake_done.is_set()
+
+    def test_wrong_verifier_rejects(self):
+        """Echoed seed is correct but the verifier bytes are wrong."""
+        proto = self._make_proto()
+        challenge = bytes.fromhex("01020304")
+        proto._pending_challenge = challenge
+        key_prefix = b"\xAB\xCD"
+        body = challenge + key_prefix
+        # Deliberately wrong verifier.
+        payload = body + b"\x00\x00"
+
+        proto._handle_handshake_response(payload)
+
+        assert proto._key_prefix is None
+        assert proto._handshake_done.is_set()
+
+    def test_short_response_rejects(self):
+        """Payload shorter than 8 bytes — reject."""
+        proto = self._make_proto()
+        proto._pending_challenge = bytes.fromhex("01020304")
+
+        proto._handle_handshake_response(b"\x00\x00\x00")  # 3 bytes
+
+        assert proto._key_prefix is None
+        assert proto._handshake_done.is_set()

--- a/tests/test_protocol_full.py
+++ b/tests/test_protocol_full.py
@@ -238,20 +238,32 @@ class TestHandshake:
     """Test HU handshake flow."""
 
     @pytest.mark.asyncio
-    async def test_handshake_sends_challenge(self):
+    async def test_handshake_sends_challenge(self, monkeypatch):
         proto = MelittaProtocol()
         write_calls = []
+
+        # Pin the seed so we can craft the exact echoed-seed +
+        # verifier the response handler now requires.
+        fixed_seed = b"\x01\x02\x03\x04"
+        monkeypatch.setattr(
+            "custom_components.melitta_barista.protocol.os.urandom",
+            lambda n: fixed_seed if n == 4 else b"\x00" * n,
+        )
 
         async def mock_write(data: bytes) -> None:
             write_calls.append(data)
 
-        # Simulate machine responding with HU response in background
         async def respond():
             await asyncio.sleep(0.05)
-            # Build HU response: challenge(4) + key_prefix(2) + validation(2)
-            response_payload = b"\x01\x02\x03\x04\xAA\xBB\xCC\xDD"
+            # Wire layout after our verification PR:
+            #   payload[0:4]  = echoed seed (= fixed_seed)
+            #   payload[4:6]  = key_prefix
+            #   payload[6:8]  = hu_verifier(payload[0:6])
+            key_prefix = b"\xAA\xBB"
+            body = fixed_seed + key_prefix
+            verifier = proto._brand.hu_verifier(body, 0, len(body))
+            response_payload = body + verifier
             cmd_bytes = b"HU"
-            # Compute correct checksum: ~(sum(cmd + payload)) & 0xFF
             cs = (~sum(cmd_bytes + response_payload)) & 0xFF
             frame = bytes([FRAME_START]) + cmd_bytes
             if proto._rc4_key:
@@ -266,7 +278,7 @@ class TestHandshake:
         await task
 
         assert len(write_calls) > 0  # HU frame was sent
-        assert proto._key_prefix is not None
+        assert proto._key_prefix == b"\xAA\xBB"
         assert result is True
 
     @pytest.mark.asyncio
@@ -584,14 +596,19 @@ class TestTryParseFrameEdgeCases:
 
 
 class TestHandshakeResponseEdgeCases:
-    """Cover _handle_handshake_response short payload (lines 517-518)."""
+    """Cover _handle_handshake_response short payload and reject paths."""
 
     def test_handshake_response_too_short(self):
-        """HU response with less than 6 bytes is rejected."""
+        """HU response with fewer than 8 bytes is rejected.
+
+        New contract (post-Gap-#1 fix): the response handler now also
+        sets `_handshake_done` on rejection so `perform_handshake`
+        returns False fast instead of hanging until the frame-timeout.
+        """
         proto = MelittaProtocol()
         proto._handle_handshake_response(b"\x01\x02\x03")
         assert proto._key_prefix is None
-        assert not proto._handshake_done.is_set()
+        assert proto._handshake_done.is_set()
 
 
 class TestHighLevelReadAPI:


### PR DESCRIPTION
## Summary

PR A from the protocol-verification plan. Zero-risk correctness fix; no behavior change on a working machine, but failure modes for the off-happy-path become loud and fast.

The HU response handler now requires both:
- `payload[0:4] == sent challenge` (echoed seed)
- `payload[6:8] == hu_verifier(payload[0:6])` (response verifier)

Our handler used to take `payload[4:6]` as the session key on faith. If the machine returned anything else — corrupt frame, late notify from a previous session, wrong-brand device — we'd install a junk session key and every subsequent RC4-encrypted frame would decrypt to gibberish, with no log line pointing back at the handshake.

### Wire layout (post-RC4-decrypt, 8 bytes)

```
[0:4)  echoed seed       — must equal challenge we sent
[4:6)  session_key       — our `_key_prefix`
[6:8)  response verifier — must equal hu_verifier(payload[0:6])
```

### Changes

- `EugsterProtocol._pending_challenge` — new field, stores the 4-byte seed across the request/response of a single handshake.
- `perform_handshake` clears `_pending_challenge` on entry, sets it after `os.urandom(4)`.
- `_handle_handshake_response`:
  - Length gate tightened from `< 6` to `< 8`.
  - Verifies echoed seed against `_pending_challenge`.
  - Recomputes HU verifier over `payload[0:6]` and compares to `payload[6:8]`.
  - On any mismatch: `_key_prefix = None`, WARNING log, `_handshake_done.set()` — so `perform_handshake` returns `False` immediately instead of hanging until `frame_timeout`.

### Tests

- 4 new tests in `tests/test_protocol.py::TestHandshakeResponseVerification`:
  1. Happy path (valid seed + verifier → key prefix installed)
  2. Wrong echoed seed → rejected
  3. Wrong verifier → rejected
  4. Short response (< 8 bytes) → rejected
- `tests/test_protocol_full.py::TestHandshake::test_handshake_sends_challenge` updated to pin `os.urandom` and craft a matching response.
- `tests/test_protocol_full.py::TestHandshakeResponseEdgeCases::test_handshake_response_too_short` updated for the new "event set on reject" contract.
- Full suite: 956 passed (was 952 on v0.76.0).

### Version

0.76.0 → **0.76.1** (PATCH — pure validation tightening).

## Test plan

- [x] `pytest tests/` — 956 passed
- [x] `pytest tests/test_protocol.py::TestHandshakeResponseVerification -v` — 4/4 green
- [ ] Field validation by #15 reporter on NIVO 8101 after 0.76.1 ships — should still pair cleanly. If they see a new `HU handshake rejected: ...` WARNING in HA logs, that's a separate firmware quirk that wasn't visible before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)