### PR TITLE
fix: stop registering Total Cups on Nivona, align stats with vendor register set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
+## [0.77.0] — 2026-05-28
+
+### Fixed
+- **`Total Cups` sensor no longer registers on Nivona** (Gap #12 from `docs/PROTOCOL_VERIFICATION.md`; reported in #15). The legacy `MelittaTotalCupsSensor` reads HR id 150 (`TOTAL_CUPS_ID`), which is a Melitta-specific register that does not exist on Nivona machines — so the sensor stayed `unknown` forever on every Nivona install. The equivalent "total brews" counter on Nivona is already exposed via the capability-driven `BrandStatSensor` (`total_beverages`, id 213 on the 8000 family, id 215 on the 1030 family). For Melitta the sensor still registers unchanged.
+
+### Changed
+- **Stat slugs renamed to match the official Nivona APK** (`brands/nivona.py`):
+  - 8000 family, id 206: `warm_milk` → `hot_milk` (APK uses `Anz_Bezuege_Heisse_Milch`).
+  - 1030/1040 family, id 201: `lungo` → `coffee` (APK uses `Anz_Bezuege_Coffee`).
+  Existing entity registry entries are migrated automatically via `async_migrate_entry` v2 → v3 — HA's long-term statistics history follows the rename.
+- **`_STATS_1030` id 224** (`beverages_via_kanne`) title updated to `"Beverages via Kanne (experimental)"` to mark it as unverified — this register is not in the APK's `diagnostics_0.json`. Keep watching field reports; remove the entry in a future release if no real machine ever reports a non-zero value.
+
+### Added (new diagnostic sensors for NIVO 8000-family)
+All four are read-only `HR` register polls; the values are present in the APK's `diagnostics_X.json` but were missing from our `_STATS_8000`:
+- id 211 `grinding_count` (`Anz_Mahlung`) — total grinder uses.
+- id 212 `reserve_count` (`Anz_Reserve`) — internal reserve counter (purpose unclear from APK; surfaced for parity).
+- id 602 `descale_status` (`Entkalken_Status`) — descale state machine flag, complements id 600 (descale percent) and id 601 (descale warning).
+- id 630 `frother_rinse_needed` (`SpuelenAufsch_Notwendig`) — flag that the milk frother needs a rinse cycle.
+
+### Added (1030/1040 family)
+- id 210 `my_coffee` (`Anz_Bezuege_MyCoffee`) — the MyCoffee dispense counter was missing entirely on these families. Cross-references the existing MyCoffee slot system.
+
+### Migration
+- Config entry version bumped from 2 → 3. `async_migrate_entry` handles the slug renames automatically on the next HA restart after upgrade. Old entity IDs (e.g. `sensor.<name>_warm_milk`) become the new ones (`sensor.<name>_hot_milk`); statistics history is preserved.
+
+### Tests
+- 3 new tests in `tests/test_brands.py` verifying per-family stat sizes and specific (id, key) APK alignment.
+- 2 new tests in `tests/test_sensor.py` for the Total Cups brand gating.
+- 3 new tests in `tests/test_init.py::TestMigrateEntryV2ToV3` covering both renames and a Melitta no-op case.
+- Full suite: 963 passed (was 956 on v0.76.1).
+
 ## [0.76.1] — 2026-05-28
 
 ### Fixed

--- a/custom_components/melitta_barista/__init__.py
+++ b/custom_components/melitta_barista/__init__.py
@@ -701,7 +701,15 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     v1 → v2: introduce ``brand`` field. All pre-existing entries are
     Melitta (the only previously supported brand).
+
+    v2 → v3 (0.77.0): rename two Nivona stat-sensor slugs to match the
+    official APK's ``diagnostics_*.json`` register descriptions. The
+    underlying register IDs (and therefore the wire reads) are
+    unchanged; only the entity ``unique_id`` and slug change, so HA's
+    statistics history follows the renames.
     """
+    from homeassistant.helpers import entity_registry as er  # noqa: PLC0415
+
     if entry.version < 2:
         new_data = {**entry.data}
         new_data.setdefault(CONF_BRAND, DEFAULT_BRAND)
@@ -710,6 +718,53 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Migrated entry %s to v2 (brand=%s)",
             entry.entry_id, new_data[CONF_BRAND],
         )
+
+    if entry.version < 3:
+        # Only Nivona entries carry BrandStatSensor; Melitta uses
+        # different sensors and is unaffected by these slug changes.
+        if entry.data.get(CONF_BRAND) != DEFAULT_BRAND:
+            address: str = entry.data.get(CONF_ADDRESS, "")
+            if address:
+                # (old_key → new_key) slug renames for BrandStatSensor.
+                # Unique-id format is `{address}_stat_{key}` per
+                # `sensor.BrandStatSensor.unique_id`.
+                renames = {
+                    # 8000 family — APK id 206 is Hot Milk, not Warm.
+                    "warm_milk": "hot_milk",
+                    # 1030/1040 family — APK id 201 is Coffee, not Lungo.
+                    "lungo": "coffee",
+                }
+                registry = er.async_get(hass)
+                for old_key, new_key in renames.items():
+                    old_uid = f"{address}_stat_{old_key}"
+                    new_uid = f"{address}_stat_{new_key}"
+                    eid = registry.async_get_entity_id(
+                        "sensor", DOMAIN, old_uid,
+                    )
+                    if eid is None:
+                        continue
+                    # If the new unique_id already exists, leave the old
+                    # one alone — the user (or a partial prior migration)
+                    # already has the renamed entity; renaming on top of
+                    # it would collide.
+                    if registry.async_get_entity_id(
+                        "sensor", DOMAIN, new_uid,
+                    ) is not None:
+                        _LOGGER.warning(
+                            "Skipping stat rename %s → %s on %s: "
+                            "target unique_id already exists",
+                            old_uid, new_uid, eid,
+                        )
+                        continue
+                    registry.async_update_entity(eid, new_unique_id=new_uid)
+                    _LOGGER.info(
+                        "Renamed stat sensor unique_id %s → %s (entity %s)",
+                        old_uid, new_uid, eid,
+                    )
+
+        hass.config_entries.async_update_entry(entry, version=3)
+        _LOGGER.info("Migrated entry %s to v3 (stat sensor slug renames)", entry.entry_id)
+
     return True
 
 

--- a/custom_components/melitta_barista/brands/nivona.py
+++ b/custom_components/melitta_barista/brands/nivona.py
@@ -377,11 +377,18 @@ _STATS_8000: tuple[StatDescriptor, ...] = (
     _count(203, "cappuccino", "Cappuccino"),
     _count(204, "caffe_latte", "Caffè latte"),
     _count(205, "macchiato", "Latte macchiato"),
-    _count(206, "warm_milk", "Warm milk"),
+    # APK id 206 = Anz_Bezuege_Heisse_Milch (Hot milk, not Warm).
+    # Slug changed from `warm_milk` in v0.77.0 to match APK; entity
+    # registry migration in async_migrate_entry v2 → v3 renames
+    # existing user entries.
+    _count(206, "hot_milk", "Hot milk"),
     _count(207, "hot_water", "Hot water"),
     _count(208, "my_coffee", "My coffee"),
     _count(209, "steam_drinks", "Steam drinks"),
     _count(210, "powder_coffee", "Powder coffee"),
+    # Added in v0.77.0 (Gap #9) from APK diagnostics_X.json:
+    _count(211, "grinding_count", "Grinding count", "maintenance"),
+    _count(212, "reserve_count", "Reserve count", "maintenance"),
     _count(213, "total_beverages", "Total beverages"),
     _count(214, "clean_coffee_system", "Clean coffee system", "maintenance"),
     _count(215, "clean_frother", "Clean frother", "maintenance"),
@@ -391,10 +398,14 @@ _STATS_8000: tuple[StatDescriptor, ...] = (
     _count(221, "beverages_via_app", "Beverages via app", "maintenance"),
     _pct(600, "descale_percent", "Descale progress"),
     _flag(601, "descale_warning", "Descale warning"),
+    # Added in v0.77.0 (Gap #9): APK Entkalken_Status — descale state machine.
+    _flag(602, "descale_status", "Descale status"),
     _pct(610, "brew_unit_clean_percent", "Brew unit clean progress"),
     _flag(611, "brew_unit_clean_warning", "Brew unit clean warning"),
     _pct(620, "frother_clean_percent", "Frother clean progress"),
     _flag(621, "frother_clean_warning", "Frother clean warning"),
+    # Added in v0.77.0 (Gap #9): APK SpuelenAufsch_Notwendig — frother-rinse needed.
+    _flag(630, "frother_rinse_needed", "Frother rinse needed"),
     _pct(640, "filter_percent", "Filter progress"),
     _flag(641, "filter_warning", "Filter warning"),
     _flag(642, "filter_dependency", "Filter dependency"),
@@ -515,7 +526,10 @@ _STATS_900_LIGHT: tuple[StatDescriptor, ...] = _STATS_900
 # Filter dependency is 101.
 _STATS_1030: tuple[StatDescriptor, ...] = (
     _count(200, "espresso", "Espresso"),
-    _count(201, "lungo", "Lungo"),
+    # APK id 201 = Anz_Bezuege_Coffee. We used to label it `lungo` —
+    # corrected in v0.77.0 (Gap #10); entity registry migration renames
+    # existing user entries.
+    _count(201, "coffee", "Coffee"),
     _count(202, "americano", "Americano"),
     _count(203, "cappuccino", "Cappuccino"),
     _count(204, "caffe_latte", "Caffè latte"),
@@ -524,6 +538,9 @@ _STATS_1030: tuple[StatDescriptor, ...] = (
     _count(207, "hot_milk", "Hot milk"),
     _count(208, "milk_foam", "Milk foam"),
     _count(209, "hot_water", "Hot water"),
+    # Added in v0.77.0 (Gap #10): APK diagnostics_0.json id 210 is
+    # Anz_Bezuege_MyCoffee — was missing entirely on 1030/1040.
+    _count(210, "my_coffee", "My coffee"),
     _count(211, "steam_drinks", "Steam drinks"),
     _count(212, "powder_coffee", "Powder coffee"),
     _count(213, "single_cup", "Single cup brews"),
@@ -537,7 +554,10 @@ _STATS_1030: tuple[StatDescriptor, ...] = (
     _count(221, "filter_changes", "Filter changes", "maintenance"),
     _count(222, "descaling", "Descaling", "maintenance"),
     _count(223, "beverages_via_app", "Beverages via app", "maintenance"),
-    _count(224, "beverages_via_kanne", "Beverages via Kanne", "maintenance"),
+    # id 224 is not in APK diagnostics_0.json — origin unclear. Kept
+    # enabled until we get a field-confirmed read from a real NICR
+    # 1030/1040; "(experimental)" in the title flags the uncertainty.
+    _count(224, "beverages_via_kanne", "Beverages via Kanne (experimental)", "maintenance"),
     _pct(600, "descale_percent", "Descale progress"),
     _flag(601, "descale_warning", "Descale warning"),
     _pct(610, "brew_unit_clean_percent", "Brew unit clean progress"),

--- a/custom_components/melitta_barista/config_flow.py
+++ b/custom_components/melitta_barista/config_flow.py
@@ -137,7 +137,7 @@ def _describe_advertisement(
 class MelittaBaristaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle the config flow for Melitta and Nivona coffee machines."""
 
-    VERSION = 2
+    VERSION = 3
 
     @staticmethod
     @callback

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -31,5 +31,5 @@
     "aiosqlite>=0.19.0",
     "pydantic>=2.0"
   ],
-  "version": "0.76.1"
+  "version": "0.77.0"
 }

--- a/custom_components/melitta_barista/sensor.py
+++ b/custom_components/melitta_barista/sensor.py
@@ -76,8 +76,17 @@ async def async_setup_entry(
         MelittaFirmwareSensor(client, entry, name),
         MelittaSerialSensor(client, entry, name),
         MelittaFeaturesSensor(client, entry, name),
-        MelittaTotalCupsSensor(client, entry, name),
     ]
+
+    # Legacy MelittaTotalCupsSensor reads HR id=150 (TOTAL_CUPS_ID) which
+    # is a Melitta-specific register. On Nivona the register doesn't
+    # exist and the sensor stayed at `unknown` (reported in #15). For
+    # non-Melitta brands the equivalent counter is exposed via the
+    # capability-driven `BrandStatSensor` (`total_beverages`, id 213 on
+    # 8000 family, id 215 on 1030, etc.) — no need to register the
+    # Melitta-specific sensor at all.
+    if client.brand.brand_slug == "melitta":
+        entities.append(MelittaTotalCupsSensor(client, entry, name))
 
     # Brand-capability-driven stat sensors (Nivona). Melitta has its own
     # hand-tailored total_cups + per-recipe counters; generic stat sensors

--- a/tests/test_brands.py
+++ b/tests/test_brands.py
@@ -272,9 +272,15 @@ def test_nivona_settings_per_family():
 
 
 def test_nivona_stats_for_stats_families():
-    """Every Nivona family exposes its authoritative stat ID set
-    (v0.49.0+). Sizes are the per-family counts from the canonical
-    stats-factory mapping.
+    """Every Nivona family exposes its authoritative stat ID set.
+
+    Sizes are the per-family counts from the canonical stats-factory
+    mapping. Updated in PR B (Gaps #9 + #10):
+
+    - 8000 grows by 4 (ids 211 grinding, 212 reserve, 602 descale status,
+      630 frother-rinse needed) from the APK diagnostics_X.json list.
+    - 1030 grows by 1 (id 210 my_coffee — was missing entirely).
+    - 1040 inherits the 1030 change.
     """
     np_ = NivonaProfile()
     expected_sizes = {
@@ -283,15 +289,53 @@ def test_nivona_stats_for_stats_families():
         "79x": 17,       # 700 minus selector 204 (Cappuccino)
         "900": 31,       # 22 counters + 8 gauges + 101 dep
         "900-light": 31,
-        "1030": 33,      # 24 counters + 8 gauges + 101 dep
-        "1040": 32,      # 1030 minus id 207 (HeisseMilch)
-        "8000": 27,
+        "1030": 34,      # 25 counters + 8 gauges + 101 dep (was 33, +1 for id 210 my_coffee)
+        "1040": 33,      # 1030 minus id 207 (HeisseMilch)
+        "8000": 31,      # 27 + 4 (211, 212, 602, 630) per APK diagnostics_X.json
     }
     for fk, size in expected_sizes.items():
         caps = np_.capabilities_for(fk)
         assert len(caps.stats) == size, (
             f"Nivona family {fk} expected {size} stats, got {len(caps.stats)}"
         )
+
+
+def test_stats_8000_apk_alignment():
+    """Specific (id, key) pairs that must match APK diagnostics_X.json.
+
+    Cross-checked against
+    ``apk_study/decompiled_per_class/EugsterMobileApp/EugsterMobileApp.Model.Configuration.diagnostics_X.json``.
+    """
+    caps = NivonaProfile().capabilities_for("8000")
+    by_id = {s.stat_id: s for s in caps.stats}
+    # APK id 206 is `Anz_Bezuege_Heisse_Milch` (Hot milk); PR B renames
+    # our slug from `warm_milk` to `hot_milk`.
+    assert by_id[206].key == "hot_milk"
+    # Newly added entries (Gap #9) — all from diagnostics_X.json.
+    assert by_id[211].key == "grinding_count"
+    assert by_id[212].key == "reserve_count"
+    assert by_id[602].key == "descale_status"
+    assert by_id[630].key == "frother_rinse_needed"
+
+
+def test_stats_1030_apk_alignment():
+    """Specific (id, key) pairs for 1030 must match APK diagnostics_0.json.
+
+    Gap #10 fixes:
+    - id 201 is "Anz_Bezuege_Coffee" in APK; we used to call it `lungo`.
+    - id 210 is "Anz_Bezuege_MyCoffee" in APK; we used to skip it.
+    - id 224 stays but is marked "experimental" in title (not in APK).
+    """
+    caps = NivonaProfile().capabilities_for("1030")
+    by_id = {s.stat_id: s for s in caps.stats}
+    assert by_id[201].key == "coffee", (
+        "APK diagnostics_0.json id 201 = Anz_Bezuege_Coffee, not Lungo"
+    )
+    assert 210 in by_id, "APK id 210 = MyCoffee — must be exposed on 1030"
+    assert by_id[210].key == "my_coffee"
+    # id 224 retained for now; title carries the 'experimental' marker.
+    assert 224 in by_id
+    assert "experimental" in by_id[224].title.lower()
 
 
 def test_nivona_per_model_capabilities_overrides():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -838,3 +838,126 @@ def test_time_platform_included_in_platforms():
     from custom_components.melitta_barista import PLATFORMS
 
     assert Platform.TIME in PLATFORMS
+
+
+class TestMigrateEntryV2ToV3:
+    """Entity-registry slug renames for Nivona stat sensors (PR B / v0.77.0).
+
+    Old (v0.76.x) Nivona installations had `BrandStatSensor` entities
+    with two now-incorrect slugs:
+    - `warm_milk` on 8000 family — should be `hot_milk`.
+    - `lungo` on 1030 family — should be `coffee`.
+
+    On migration to v3, async_migrate_entry rewrites the entity
+    registry's unique_id so HA's statistics history follows the rename.
+    """
+
+    async def test_v2_to_v3_renames_warm_milk_to_hot_milk(
+        self, hass: HomeAssistant,
+    ) -> None:
+        from homeassistant.helpers import entity_registry as er
+
+        from custom_components.melitta_barista import async_migrate_entry
+        from custom_components.melitta_barista.const import (
+            CONF_BRAND, DOMAIN,
+        )
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={**MOCK_CONFIG_DATA, CONF_BRAND: "nivona"},
+            version=2,
+            unique_id="aabbccddeeff",
+        )
+        entry.add_to_hass(hass)
+
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"{MOCK_ADDRESS}_stat_warm_milk",
+            suggested_object_id="stat_warm_milk_8000",
+        )
+
+        assert await async_migrate_entry(hass, entry) is True
+
+        # Old unique_id is gone, new one is present.
+        assert registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{MOCK_ADDRESS}_stat_warm_milk",
+        ) is None
+        new_eid = registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{MOCK_ADDRESS}_stat_hot_milk",
+        )
+        assert new_eid is not None
+        assert entry.version == 3
+
+    async def test_v2_to_v3_renames_lungo_to_coffee(
+        self, hass: HomeAssistant,
+    ) -> None:
+        from homeassistant.helpers import entity_registry as er
+
+        from custom_components.melitta_barista import async_migrate_entry
+        from custom_components.melitta_barista.const import (
+            CONF_BRAND, DOMAIN,
+        )
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={**MOCK_CONFIG_DATA, CONF_BRAND: "nivona"},
+            version=2,
+            unique_id="aabbccddeeff2",
+        )
+        entry.add_to_hass(hass)
+
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"{MOCK_ADDRESS}_stat_lungo",
+            suggested_object_id="stat_lungo_1030",
+        )
+
+        assert await async_migrate_entry(hass, entry) is True
+
+        assert registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{MOCK_ADDRESS}_stat_lungo",
+        ) is None
+        assert registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{MOCK_ADDRESS}_stat_coffee",
+        ) is not None
+
+    async def test_v2_to_v3_skips_melitta(
+        self, hass: HomeAssistant,
+    ) -> None:
+        """Melitta entries have different sensors — rename must be no-op."""
+        from homeassistant.helpers import entity_registry as er
+
+        from custom_components.melitta_barista import async_migrate_entry
+        from custom_components.melitta_barista.const import (
+            CONF_BRAND, DEFAULT_BRAND, DOMAIN,
+        )
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={**MOCK_CONFIG_DATA, CONF_BRAND: DEFAULT_BRAND},
+            version=2,
+            unique_id="aabbccddeeff3",
+        )
+        entry.add_to_hass(hass)
+
+        registry = er.async_get(hass)
+        # If a Melitta install somehow had a `warm_milk` stat entity
+        # (it shouldn't — Melitta uses different sensors), the migration
+        # must leave it untouched.
+        registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"{MOCK_ADDRESS}_stat_warm_milk",
+            suggested_object_id="melitta_should_not_be_touched",
+        )
+
+        assert await async_migrate_entry(hass, entry) is True
+
+        assert registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{MOCK_ADDRESS}_stat_warm_milk",
+        ) is not None
+        assert entry.version == 3

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -164,3 +164,50 @@ async def test_action_required_sensor(
     action = [s for s in hass.states.async_all("sensor") if "action" in s.entity_id or "manipulation" in s.entity_id]
     assert len(action) >= 1
     assert action[0].state == "Fill Water"
+
+
+def _mock_nivona_client(status=None):
+    """Same as `_mock_client` but with brand_slug = 'nivona' and no HC/HJ.
+
+    Used to verify brand-gated sensor registration logic.
+    """
+    client = _mock_client(status=status)
+    client.brand.brand_slug = "nivona"
+    client.brand.brand_name = "Nivona"
+    client.brand.supported_extensions = frozenset()
+    # capabilities resolved before setup so BrandStatSensor gets created
+    client.capabilities = None
+    return client
+
+
+async def test_total_cups_sensor_only_for_melitta(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Legacy `MelittaTotalCupsSensor` reads HR id 150 (`TOTAL_CUPS_ID`),
+    which is a Melitta-only register. On Nivona the register doesn't
+    exist and the sensor was stuck at `unknown` (reported in #15).
+    Gap #12 fix: gate registration to brand_slug == 'melitta'.
+
+    For Melitta the entity still appears as before.
+    """
+    client = _mock_nivona_client()
+    await _setup_integration(hass, mock_entry, client)
+
+    sensor_ids = [s.entity_id for s in hass.states.async_all("sensor")]
+    # On Nivona, NO sensor.*_total_cups should be present.
+    assert not any(eid.endswith("_total_cups") or "total_cups" in eid for eid in sensor_ids), (
+        f"Total Cups sensor must not be registered for Nivona; saw: {sensor_ids}"
+    )
+
+
+async def test_total_cups_sensor_still_created_for_melitta(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Sanity check that Melitta brand still gets the Total Cups sensor."""
+    client = _mock_client()  # default brand = melitta
+    await _setup_integration(hass, mock_entry, client)
+
+    sensor_ids = [s.entity_id for s in hass.states.async_all("sensor")]
+    assert any("total_cups" in eid for eid in sensor_ids), (
+        f"Total Cups sensor should still register for Melitta; saw: {sensor_ids}"
+    )


### PR DESCRIPTION
## Summary

PR B from the protocol-verification plan. Addresses the only remaining bug reported by #15 (`Total Cups` stuck at `unknown` on NIVO 8101).

### Gap #12 — `Total Cups` sensor on Nivona (the #15 bug)

`MelittaTotalCupsSensor` reads HR id 150 (`TOTAL_CUPS_ID`). That register is **Melitta-specific** — on Nivona it doesn't exist, so the sensor stayed `unknown` forever on every Nivona install. The legacy sensor is now gated to `brand_slug == "melitta"`; Nivona users see the equivalent via the capability-driven `total_beverages` stat sensor (id 213 on 8000, id 215 on 1030).

### Gap #9 — `_STATS_8000` completeness + label fix

Cross-checked against the vendor register set. Changes:
- Slug rename **`warm_milk` → `hot_milk`** for id 206 (vendor labels this counter "Heisse Milch" / hot milk).
- Four new diagnostic sensors:
  - id 211 `grinding_count` ("Anz_Mahlung")
  - id 212 `reserve_count` ("Anz_Reserve")
  - id 602 `descale_status` ("Entkalken_Status")
  - id 630 `frother_rinse_needed` ("SpuelenAufsch_Notwendig")

### Gap #10 — `_STATS_1030` ID mismatches

Cross-checked against the vendor register set for the 1030/1040 family:
- Slug rename **`lungo` → `coffee`** for id 201 (vendor labels this counter "Coffee", not Lungo).
- Added id 210 `my_coffee` ("Anz_Bezuege_MyCoffee") — was missing entirely.
- id 224 `beverages_via_kanne` title prefixed with "(experimental)" — register not confirmed in vendor reference data; keep until field-confirmed.

### Migration

Entity registry `unique_id` rename handled automatically by `async_migrate_entry` v2 → v3:
- `<addr>_stat_warm_milk` → `<addr>_stat_hot_milk` (Nivona only)
- `<addr>_stat_lungo` → `<addr>_stat_coffee` (Nivona only)

Long-term statistics history follows the rename. Melitta installs are unaffected.

## Test plan

- [x] `pytest tests/` — 963 passed (was 956 on v0.76.1)
- [x] 3 new tests in `tests/test_brands.py` for stats sizes + register-set alignment
- [x] 2 new tests in `tests/test_sensor.py` for Total Cups brand gating (Nivona missing, Melitta present)
- [x] 3 new tests in `tests/test_init.py::TestMigrateEntryV2ToV3` for the slug renames + Melitta no-op
- [ ] Field validation by #15 reporter on NIVO 8101 — `Total Cups` should disappear, new diagnostic sensors should populate, `Hot milk` should show the value previously labeled `Warm milk`

## Version

0.76.1 → **0.77.0** (MINOR — new sensors + schema migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)