### PR TITLE
feat: add first_mycoffee_selector to MachineCapabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
+## [0.77.1] — 2026-05-28
+
+### Added
+- **`MachineCapabilities.first_mycoffee_selector`** — new constant (default `20`) carrying the MyCoffee brew-selector base. Per the official Nivona APK (`EugsterMobileApp.Model.ExtensionMethods`), every Nivona model uses `firstMyCoffeJobProductParameter = 20`, so to brew MyCoffee slot N the HE command needs `payload[3] = 20 + N`. Without this constant exposed in capabilities, callers had to hardcode the magic number. This PR is purely additive — no behavior change yet; consumers will be wired up in a follow-up PR (Gap #6 in `docs/PROTOCOL_VERIFICATION.md`).
+
+### Tests
+- `tests/test_brands.py::test_nivona_first_mycoffee_selector_is_20` locks the default at 20 for all eight Nivona families.
+- Full suite: 964 passed (was 963 on v0.77.0).
+
 ## [0.77.0] — 2026-05-28
 
 ### Fixed

--- a/custom_components/melitta_barista/brands/base.py
+++ b/custom_components/melitta_barista/brands/base.py
@@ -99,6 +99,17 @@ class MachineCapabilities:
     my_coffee_slots: int = 0
     strength_levels: int = 5
     has_aroma_balance: bool = False
+    # Brew-selector base for MyCoffee slots. On Nivona (per APK
+    # `CoffeeMachineRecipeCapability(model, strength, mycoffees,
+    # firstMyCoffeJobProductParameter=20, ...)` in
+    # `EugsterMobileApp.Model.ExtensionMethods.cs`), MyCoffee slot N
+    # is brewed by sending HE with `payload[3] = first_mycoffee_selector
+    # + N`. The APK uses 20 for every Nivona model it ships. Melitta
+    # has its own MyCoffee scheme (per-slot DirectKey IDs) and doesn't
+    # use this field — the default sits unused.
+    #
+    # Added in v0.77.1 (Gap #4 in `docs/PROTOCOL_VERIFICATION.md`).
+    first_mycoffee_selector: int = 20
     image_transfer: bool | None = None               # None until HI answers
 
     # Protocol quirks

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -31,5 +31,5 @@
     "aiosqlite>=0.19.0",
     "pydantic>=2.0"
   ],
-  "version": "0.77.0"
+  "version": "0.77.1"
 }

--- a/tests/test_brands.py
+++ b/tests/test_brands.py
@@ -338,6 +338,30 @@ def test_stats_1030_apk_alignment():
     assert "experimental" in by_id[224].title.lower()
 
 
+def test_nivona_first_mycoffee_selector_is_20():
+    """Every Nivona family advertises MyCoffee brew-selector base 20.
+
+    Cross-referenced from APK
+    ``EugsterMobileApp.Model.ExtensionMethods.cs:17-101`` —
+    `CoffeeMachineRecipeCapability(model, strength_levels, mycoffees,
+    firstMyCoffeJobProductParameter=20, ...)`. The constant is the
+    same (20) for every Nivona model the APK ships, including NIVO
+    8000 family and all NICR 6xx/7xx/79x/9xx/10xx variants.
+
+    MyCoffee slot N maps to HE.payload[3] = 20 + N when brewing.
+    """
+    np_ = NivonaProfile()
+    for fk in (
+        "600", "700", "79x", "900", "900-light",
+        "1030", "1040", "8000",
+    ):
+        caps = np_.capabilities_for(fk)
+        assert caps.first_mycoffee_selector == 20, (
+            f"Family {fk} must use APK base 20 for MyCoffee brew selectors; "
+            f"got {caps.first_mycoffee_selector}"
+        )
+
+
 def test_nivona_per_model_capabilities_overrides():
     """capabilities_for_model returns per-model my_coffee_slots / strength."""
     np_ = NivonaProfile()


### PR DESCRIPTION
## Summary

PR C from the protocol-verification plan.

**Pure additive change**: one new dataclass field on `MachineCapabilities` with a default. No consumer wired up yet; no behavior change. Sets up the foundation for the MyCoffee brew-by-slot feature in a later PR.

### Context

The vendor protocol uses `first_mycoffee_selector = 20` for every Nivona model. When a user picks "Brew MyCoffee slot N", the HE command sent to the machine has `payload[3] = 20 + N`. Without this constant exposed in our capabilities, future MyCoffee brew plumbing would have to hardcode the magic number.

### Change

```python
@dataclass(frozen=True)
class MachineCapabilities:
    ...
    my_coffee_slots: int = 0
    strength_levels: int = 5
    has_aroma_balance: bool = False
+   first_mycoffee_selector: int = 20   # NEW
```

Melitta has its own MyCoffee scheme (DirectKey-per-slot) and ignores the field. The default sits unused for Melitta caps.

### Tests

- `tests/test_brands.py::test_nivona_first_mycoffee_selector_is_20` locks the default at 20 for all eight Nivona families (600 / 700 / 79x / 900 / 900-light / 1030 / 1040 / 8000).
- Full suite: 964 passed (was 963 on v0.77.0).

### Version

0.77.0 → **0.77.1** (PATCH — additive constant, zero risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)