### PR TITLE
feat: factory-reset buttons for Nivona families

### DIFF
--- a/custom_components/melitta_barista/_ble_commands.py
+++ b/custom_components/melitta_barista/_ble_commands.py
@@ -378,6 +378,26 @@ class BleCommandsMixin(_MixinBase):
                     _LOGGER.exception("Error in recipe refresh callback")
         return True
 
+    async def execute_he_command(self, command_id: int) -> bool:
+        """Run an HE-with-commandId Nivona admin action.
+
+        Currently used for the factory-reset buttons
+        (`HE_CMD_FACTORY_RESET_SETTINGS` = 50, `HE_CMD_FACTORY_RESET_RECIPES`
+        = 51). Returns ``True`` on machine ACK, ``False`` on NACK /
+        timeout / disconnected.
+        """
+        if not self.connected:
+            return False
+        try:
+            return await self._protocol.execute_command(
+                self._write_ble, command_id,
+            )
+        except (BleakError, OSError, asyncio.TimeoutError):
+            _LOGGER.exception(
+                "BLE error executing HE commandId %d", command_id,
+            )
+            return False
+
     async def confirm_prompt(self) -> bool:
         """Send HY to confirm the current machine prompt (move cup, flush, ...).
 

--- a/custom_components/melitta_barista/button.py
+++ b/custom_components/melitta_barista/button.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 
 from bleak.exc import BleakError
-from homeassistant.components.button import ButtonEntity
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
@@ -15,7 +15,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .ble_client import MelittaBleClient
 from .const import (
-    FREESTYLE_RECIPE_TYPE, PROMPT_MANIPULATIONS, RECIPE_NAMES, MachineProcess,
+    FREESTYLE_RECIPE_TYPE, HE_CMD_FACTORY_RESET_RECIPES,
+    HE_CMD_FACTORY_RESET_SETTINGS, PROMPT_MANIPULATIONS, RECIPE_NAMES,
+    MachineProcess,
     PROCESS_MAP, INTENSITY_MAP, AROMA_MAP, TEMPERATURE_MAP, SHOTS_MAP,
 )
 from .entity import MelittaDeviceMixin
@@ -62,6 +64,15 @@ async def async_setup_entry(
 
     # Confirm machine prompt (HY command) — generic
     entities.append(MelittaConfirmPromptButton(client, entry, name))
+
+    # Factory reset buttons — Nivona only. The vendor app exposes
+    # these on families 600 / 700 / 79x / 900 / 900-light / 1030 /
+    # 1040 but NOT on NIVO 8000, so we mirror that gating. Buttons
+    # are gated at runtime via the `available` property so a
+    # late-resolving family is handled gracefully.
+    if client.brand.brand_slug == "nivona":
+        entities.append(NivonaFactoryResetSettingsButton(client, entry, name))
+        entities.append(NivonaFactoryResetRecipesButton(client, entry, name))
 
     # Maintenance buttons
     entities.append(MelittaMaintenanceButton(
@@ -299,6 +310,88 @@ class MelittaResetRecipeButton(_MelittaButtonBase):
                 )
         except (BleakError, OSError, asyncio.TimeoutError):
             _LOGGER.exception("BLE error while resetting recipe %s", recipe_name)
+
+
+
+# Nivona families that expose factory-reset buttons in the vendor app.
+# NIVO 8000 does not — its settings screen has no reset entries — so
+# we follow the same gating here.
+_FACTORY_RESET_FAMILIES = frozenset(
+    {"600", "700", "79x", "900", "900-light", "1030", "1040"}
+)
+
+
+class _NivonaFactoryResetButtonBase(_MelittaButtonBase):
+    """Shared base for the two Nivona factory-reset buttons.
+
+    Both buttons send the same HE opcode with different 18-byte
+    command-id payloads (see `protocol._build_he_command_payload`).
+    Available only on Nivona families that expose the corresponding
+    menu in the vendor app — NIVO 8000 has no factory-reset menu
+    there, so we hide the entity for it.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_device_class = ButtonDeviceClass.RESTART
+    _attr_icon = "mdi:restore-alert"
+
+    # Subclasses provide these.
+    _command_id: int = 0
+    _slug: str = ""
+    _log_label: str = ""
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._client.address}_factory_reset_{self._slug}"
+
+    @property
+    def available(self) -> bool:
+        if not self._client.connected:
+            return False
+        caps = getattr(self._client, "capabilities", None)
+        if caps is None:
+            # Capability hasn't resolved yet (usually moments after
+            # connect). Stay unavailable until we know whether this is
+            # an 8000-family machine.
+            return False
+        return caps.family_key in _FACTORY_RESET_FAMILIES
+
+    async def async_press(self) -> None:
+        _LOGGER.warning(
+            "Initiating Nivona factory reset (%s, HE commandId=%d) on %s",
+            self._log_label, self._command_id, self._client.address,
+        )
+        try:
+            success = await self._client.execute_he_command(self._command_id)
+        except (BleakError, OSError, asyncio.TimeoutError):
+            _LOGGER.exception(
+                "BLE error during factory reset %s", self._log_label,
+            )
+            return
+        if not success:
+            _LOGGER.warning(
+                "Factory reset %s returned NACK or timeout — machine "
+                "may not be in a ready state",
+                self._log_label,
+            )
+
+
+class NivonaFactoryResetSettingsButton(_NivonaFactoryResetButtonBase):
+    """Reset machine-wide settings to factory defaults (HE commandId 50)."""
+
+    _attr_name = "Factory Reset Settings"
+    _command_id = HE_CMD_FACTORY_RESET_SETTINGS
+    _slug = "settings"
+    _log_label = "settings"
+
+
+class NivonaFactoryResetRecipesButton(_NivonaFactoryResetButtonBase):
+    """Reset per-recipe customizations to factory defaults (HE commandId 51)."""
+
+    _attr_name = "Factory Reset Recipes"
+    _command_id = HE_CMD_FACTORY_RESET_RECIPES
+    _slug = "recipes"
+    _log_label = "recipes"
 
 
 class MelittaConfirmPromptButton(_MelittaButtonBase):

--- a/custom_components/melitta_barista/const.py
+++ b/custom_components/melitta_barista/const.py
@@ -64,6 +64,12 @@ CMD_READ_ALPHA = "HA"
 CMD_WRITE_ALPHA = "HB"
 CMD_READ_RECIPE = "HC"
 CMD_START_PROCESS = "HE"
+
+# Nivona "execute command" IDs sent inside an HE 18-byte payload
+# (payload[0:2] = command_id BE). Each commandId triggers a maintenance /
+# admin action on the machine.
+HE_CMD_FACTORY_RESET_SETTINGS = 50  # 0x0032 — wipes machine-wide settings
+HE_CMD_FACTORY_RESET_RECIPES = 51   # 0x0033 — wipes per-recipe customizations
 CMD_WRITE_RECIPE = "HJ"
 CMD_READ_NUMERICAL = "HR"
 CMD_READ_VERSION = "HV"

--- a/custom_components/melitta_barista/protocol.py
+++ b/custom_components/melitta_barista/protocol.py
@@ -95,6 +95,24 @@ def _rc4_crypt(data: bytes, key: bytes) -> bytes:
     return bytes(out)
 
 
+def _build_he_command_payload(command_id: int) -> bytes:
+    """Build the 18-byte HE-with-commandId payload.
+
+    Layout:
+
+        payload[0:2]  command_id (BE uint16)
+        payload[2:18] zero padding
+
+    Sent under the same ``HE`` opcode that brew uses; the firmware
+    distinguishes brew from "execute command" by the payload shape.
+    See ``EugsterProtocol.execute_command``.
+    """
+    payload = bytearray(18)
+    payload[0] = (command_id >> 8) & 0xFF
+    payload[1] = command_id & 0xFF
+    return bytes(payload)
+
+
 def _calculate_checksum(frame: bytes, length: int) -> int:
     """Calculate frame checksum: ~(sum of bytes[1..length]) & 0xFF."""
     s = 0
@@ -870,6 +888,22 @@ class EugsterProtocol:
         payload[3] = recipe_selector & 0xFF
         payload[5] = 0x00 if chilled or not use_temp_recipe else 0x01
         return await self.send_and_wait_ack(CMD_START_PROCESS, bytes(payload), write_func)
+
+    async def execute_command(self, write_func, command_id: int) -> bool:
+        """Send an HE-with-commandId action (factory reset etc.).
+
+        The same opcode (`HE`, `CMD_START_PROCESS`) is used for brewing
+        and for "execute command" admin actions; the firmware
+        distinguishes them by the 18-byte payload shape. See
+        `_build_he_command_payload` for the layout.
+
+        Used by `melitta_barista.button` factory-reset entities for
+        Nivona families that expose the corresponding menu in the
+        vendor app (600 / 700 / 79x / 900 / 900-light / 1030 / 1040 —
+        NOT NIVO 8000).
+        """
+        payload = _build_he_command_payload(command_id)
+        return await self.send_and_wait_ack(CMD_START_PROCESS, payload, write_func)
 
     async def cancel_process(self, write_func, process_value: int) -> bool:
         payload = struct.pack(">h", process_value) + b"\x00\x00"

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -605,3 +605,112 @@ async def test_confirm_prompt_button_press(
     await btn.async_press()
 
     client.confirm_prompt.assert_awaited_once()
+
+
+def _mock_nivona_client(family_key="700"):
+    """Nivona client mock with capabilities preset to the given family.
+
+    Used to verify factory-reset button gating per family.
+    """
+    client = _mock_client()
+    client.brand.brand_slug = "nivona"
+    client.brand.brand_name = "Nivona"
+    client.brand.supported_extensions = frozenset()
+    # Minimal capabilities stub — enough for `available` checks.
+    caps = MagicMock()
+    caps.family_key = family_key
+    caps.my_coffee_slots = 1
+    caps.stats = ()
+    client.capabilities = caps
+    client.execute_he_command = AsyncMock(return_value=True)
+    return client
+
+
+async def test_factory_reset_buttons_registered_for_nivona_700(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Both factory-reset buttons appear for a Nivona 700-family entry."""
+    client = _mock_nivona_client(family_key="700")
+    await _setup_integration(hass, mock_entry, client)
+
+    button_ids = [
+        s.entity_id for s in hass.states.async_all("button")
+    ]
+    assert any("factory_reset_settings" in eid for eid in button_ids), button_ids
+    assert any("factory_reset_recipes" in eid for eid in button_ids), button_ids
+
+
+async def test_factory_reset_buttons_unavailable_for_nivona_8000(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Buttons register on Nivona but stay 'unavailable' for 8000 family.
+
+    Mirrors the vendor-app gating: NIVO 8000 has no factory-reset
+    menu, so the buttons stay unavailable even though they're
+    registered as Nivona-brand entities.
+    """
+    client = _mock_nivona_client(family_key="8000")
+    await _setup_integration(hass, mock_entry, client)
+
+    settings_state = next(
+        (s for s in hass.states.async_all("button")
+         if "factory_reset_settings" in s.entity_id),
+        None,
+    )
+    recipes_state = next(
+        (s for s in hass.states.async_all("button")
+         if "factory_reset_recipes" in s.entity_id),
+        None,
+    )
+    assert settings_state is not None, "Button registered (state must exist)"
+    assert recipes_state is not None
+    # Family is 8000 → button stays unavailable.
+    assert settings_state.state == "unavailable"
+    assert recipes_state.state == "unavailable"
+
+
+async def test_factory_reset_buttons_not_registered_for_melitta(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Melitta brand does not get the Nivona factory-reset buttons at all."""
+    client = _mock_client()  # default brand = melitta
+    await _setup_integration(hass, mock_entry, client)
+
+    button_ids = [s.entity_id for s in hass.states.async_all("button")]
+    assert not any(
+        "factory_reset" in eid for eid in button_ids
+    ), button_ids
+
+
+async def test_factory_reset_settings_press_invokes_command_50(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Pressing the settings reset button calls execute_he_command(50)."""
+    client = _mock_nivona_client(family_key="700")
+    await _setup_integration(hass, mock_entry, client)
+
+    settings_eid = next(
+        s.entity_id for s in hass.states.async_all("button")
+        if "factory_reset_settings" in s.entity_id
+    )
+    await hass.services.async_call(
+        "button", "press", {"entity_id": settings_eid}, blocking=True,
+    )
+    client.execute_he_command.assert_awaited_with(50)
+
+
+async def test_factory_reset_recipes_press_invokes_command_51(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Pressing the recipes reset button calls execute_he_command(51)."""
+    client = _mock_nivona_client(family_key="700")
+    await _setup_integration(hass, mock_entry, client)
+
+    recipes_eid = next(
+        s.entity_id for s in hass.states.async_all("button")
+        if "factory_reset_recipes" in s.entity_id
+    )
+    await hass.services.async_call(
+        "button", "press", {"entity_id": recipes_eid}, blocking=True,
+    )
+    client.execute_he_command.assert_awaited_with(51)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -427,3 +427,56 @@ class TestHandshakeResponseVerification:
 
         assert proto._key_prefix is None
         assert proto._handshake_done.is_set()
+
+
+class TestExecuteCommand:
+    """Generic HE-with-commandId path (factory reset etc.).
+
+    Wire layout (18 bytes, before RC4 encryption):
+        payload[0:2]  command_id (BE uint16)
+        payload[2:18] zero padding
+
+    Sent under the existing ``CMD_START_PROCESS`` ("HE") opcode. The
+    same opcode is used both for brewing (`MakeCoffee` payload) and
+    for "execute command" admin actions like factory reset; the
+    firmware distinguishes them by the shape of the 18 bytes.
+    """
+
+    def test_payload_layout_for_factory_reset_settings(self):
+        """commandId 50 (0x0032) — HE_CMD_FACTORY_RESET_SETTINGS."""
+        from custom_components.melitta_barista.protocol import (
+            _build_he_command_payload,
+        )
+        p = _build_he_command_payload(50)
+        assert len(p) == 18
+        assert p[0:2] == b"\x00\x32"
+        assert all(b == 0 for b in p[2:])
+
+    def test_payload_layout_for_factory_reset_recipes(self):
+        """commandId 51 (0x0033) — HE_CMD_FACTORY_RESET_RECIPES."""
+        from custom_components.melitta_barista.protocol import (
+            _build_he_command_payload,
+        )
+        p = _build_he_command_payload(51)
+        assert p[0:2] == b"\x00\x33"
+        assert all(b == 0 for b in p[2:])
+
+    def test_payload_distinguishable_from_brew(self):
+        """A brew payload (MakeCoffee) sets payload[1]=brew_mode (0x0B or
+        0x04), payload[3]=selector, payload[5]=0x01. A command payload
+        sets payload[0:2]=commandId, rest zero. The shapes don't
+        overlap: commandId 50/51 have payload[0]=0 (high byte) and
+        payload[1]=0x32/0x33, while brew has payload[0]=0 and
+        payload[1]=0x0B or 0x04 — distinguishable by the firmware.
+        """
+        from custom_components.melitta_barista.protocol import (
+            _build_he_command_payload,
+        )
+        cmd = _build_he_command_payload(50)
+        # commandId 50 → payload[1] = 0x32, NOT 0x0B or 0x04
+        assert cmd[1] == 0x32
+        assert cmd[1] not in (0x04, 0x0B)
+        # Selector slot stays zero for command-mode payloads
+        assert cmd[3] == 0
+        # Mode-byte slot stays zero (vs 0x01 for use-temp-recipe brew)
+        assert cmd[5] == 0


### PR DESCRIPTION
## Summary

PR D from the Tier-2 batch. Pure additive feature: two new button entities for Nivona machines that mirror the factory-reset menu in the vendor app.

### Buttons

| Entity | HE command_id | Available on |
|---|---|---|
| "Factory Reset Settings" | `HE_CMD_FACTORY_RESET_SETTINGS = 50` (0x0032) | Nivona 600 / 700 / 79x / 900 / 900-light / 1030 / 1040 |
| "Factory Reset Recipes"  | `HE_CMD_FACTORY_RESET_RECIPES = 51` (0x0033)  | (same list — NOT NIVO 8000) |

Both use `entity_category=config` and `device_class=restart` so HA dashboards surface a confirm dialog before press. Buttons register for any Nivona-brand entry but stay `unavailable` on NIVO 8000 (the vendor app has no factory-reset menu on that family, so we hide it the same way).

Melitta brand is unaffected — these buttons don't register for `brand_slug == "melitta"`.

### Protocol layer

- New `protocol._build_he_command_payload(command_id)` builds the 18-byte payload (`[id_hi, id_lo, 0, 0, ..., 0]`).
- New `EugsterProtocol.execute_command(write_func, command_id)` sends it under the `HE` opcode and awaits ACK.
- New `BleCommandsMixin.execute_he_command(command_id)` is the brand-agnostic public wrapper that the button entities call.

### Tests

- 3 tests in `tests/test_protocol.py::TestExecuteCommand` — payload-byte layout for IDs 50 and 51, brew-vs-command shape distinguishability.
- 5 tests in `tests/test_button.py` — buttons present for Nivona 700, present-but-unavailable on Nivona 8000, absent on Melitta, press → `execute_he_command(50)` / `execute_he_command(51)` wiring.
- Full suite: 972 passed (was 964 on v0.77.1).

### Release

This PR does **not** tag a release — batching with subsequent Tier-2 PRs for a single release at the end of the batch (per project preference). The CHANGELOG entry will be added in the release-prep commit at the end of the batch.

## Test plan

- [x] `pytest tests/` — 972 passed
- [ ] Field validation on a real NICR machine — press "Factory Reset Recipes" while machine is ready, confirm the recipes return to factory defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)