### PR TITLE
feat: MyCoffee slot bulk read + per-slot coffee_amount sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
+## [Unreleased] — 0.78.0
+
+### Added
+
+- **Factory reset buttons for Nivona** (`brand_slug == "nivona"`). Two new button entities, `entity_category=config`, `device_class=restart` (so HA dashboards surface a confirm dialog before press):
+  - "Factory Reset Settings" — sends `HE_CMD_FACTORY_RESET_SETTINGS = 50`, wipes machine-wide settings.
+  - "Factory Reset Recipes" — sends `HE_CMD_FACTORY_RESET_RECIPES = 51`, wipes per-recipe customizations.
+
+  Both available on families 600 / 700 / 79x / 900 / 900-light / 1030 / 1040. Hidden (entity stays unavailable) on NIVO 8000 — the vendor app doesn't expose factory-reset there either. Melitta brand is unaffected — these buttons don't register for `brand_slug == "melitta"`.
+- **Generic `execute_command(command_id)`** path on `EugsterProtocol` and `BleCommandsMixin` (as `execute_he_command`). Builds an 18-byte HE payload with `command_id` BE in `[0:2]`, sent under the existing `HE` opcode; the firmware distinguishes brew from "execute command" by payload shape.
+- **MyCoffee slot bulk read (Nivona)**. On every connect, after capability resolution, the client now reads each MyCoffee slot's `coffee_amount` register and caches the result on `MelittaBleClient.my_coffee_slots`. Per-slot `MyCoffee slot N coffee amount` diagnostic sensors expose the cached values; sensors stay `unavailable` until the first bulk read completes. Foundation for the broader MyCoffee CRUD work — write support and additional params will follow.
+
+### Tests
+- 8 new tests for the factory-reset path (`tests/test_protocol.py::TestExecuteCommand` + `tests/test_button.py`).
+- 5 new tests for MyCoffee bulk read (`tests/test_ble_client.py::TestReadMyCoffeeSlots`) + 2 sensor-registration tests (`tests/test_sensor.py`).
+- Full suite: 979 passed (was 964 on v0.77.1).
+
 ## [0.77.1] — 2026-05-28
 
 ### Added

--- a/custom_components/melitta_barista/_ble_recipes.py
+++ b/custom_components/melitta_barista/_ble_recipes.py
@@ -465,3 +465,67 @@ class BleRecipesMixin(_MixinBase):
             except Exception:  # noqa: BLE900 — callback from user code
                 _LOGGER.exception("Error in cups callback")
         return True
+
+    async def read_mycoffee_slots(self) -> bool:
+        """Bulk-read the current MyCoffee slot params from the machine.
+
+        Nivona-only: Melitta has its own MyCoffee scheme that goes
+        through DirectKey IDs and doesn't share these registers. For
+        Nivona, MyCoffee slot N lives at
+        ``MY_COFFEE_BASE_REGISTER + N * MY_COFFEE_SLOT_STRIDE``, with
+        per-family byte offsets describing which slot field is at which
+        sub-register; the layout comes from
+        ``brand.mycoffee_layout(family_key)``.
+
+        Currently reads only the ``coffee_amount`` field per slot (the
+        most informative single number per slot). Result is cached on
+        the client at ``_my_coffee_slots`` and surfaced through the
+        ``my_coffee_slots`` property. Returns ``True`` if at least the
+        cache slot list was initialised (even if some individual HR
+        reads failed), ``False`` if the call was skipped (wrong brand /
+        not connected / no capabilities).
+        """
+        if not self.connected:
+            return False
+        if getattr(self._brand, "brand_slug", "") != "nivona":
+            return False
+        caps = self._capabilities
+        if caps is None or caps.my_coffee_slots <= 0:
+            return False
+
+        # Lazily import the Nivona-specific helpers so we don't drag
+        # them into the mixin for brands that don't use them.
+        from .brands.nivona import (
+            mycoffee_layout, mycoffee_register,
+        )  # noqa: PLC0415
+
+        layout = mycoffee_layout(caps.family_key)
+        if layout is None or layout.coffee_amount_offset is None:
+            return False
+
+        slots: list[dict[str, int]] = [
+            {} for _ in range(caps.my_coffee_slots)
+        ]
+        for slot in range(caps.my_coffee_slots):
+            register = mycoffee_register(slot, layout.coffee_amount_offset)
+            try:
+                val = await self._protocol.read_numerical(
+                    self._write_ble, register,
+                )
+            except (BleakError, OSError, asyncio.TimeoutError):
+                _LOGGER.debug(
+                    "MyCoffee read failed for slot %d (register %d)",
+                    slot, register,
+                )
+                continue
+            if val is not None:
+                slots[slot]["coffee_amount"] = val
+
+        self._my_coffee_slots = slots
+        _LOGGER.debug("MyCoffee slot cache populated: %s", slots)
+        for cb in self._mycoffee_callbacks:
+            try:
+                cb()
+            except Exception:  # noqa: BLE001 — never propagate from a callback
+                _LOGGER.exception("Error in mycoffee callback")
+        return True

--- a/custom_components/melitta_barista/_ble_typing.py
+++ b/custom_components/melitta_barista/_ble_typing.py
@@ -35,6 +35,8 @@ class BleClientProtocol(Protocol):
     _cups_callbacks: list[Callable[[], None]]
     _cup_counters: dict[str, int]
     _total_cups: int | None
+    _my_coffee_slots: list[dict[str, int]] | None
+    _mycoffee_callbacks: list[Callable[[], None]]
     _brand: BrandProfile
     _capabilities: MachineCapabilities | None
     active_profile: int

--- a/custom_components/melitta_barista/ble_client.py
+++ b/custom_components/melitta_barista/ble_client.py
@@ -175,6 +175,15 @@ class MelittaBleClient(BleCommandsMixin, BleRecipesMixin, BleSettingsMixin):
         self.active_profile: int = 0  # 0 = default "My Coffee"
         self._cup_counters: dict[str, int] = {}  # recipe_name -> count
         self._total_cups: int | None = None
+        # MyCoffee bulk-read cache (PR E). Populated by
+        # `read_mycoffee_slots` on Nivona connect. ``None`` until the
+        # first successful (or partial) bulk read completes; once
+        # populated, indexed by slot 0..N-1 with a dict of param
+        # name → int value per slot. Missing keys inside a slot dict
+        # mean that particular HR read failed and the value is not
+        # known.
+        self._my_coffee_slots: list[dict[str, int]] | None = None
+        self._mycoffee_callbacks: list[Callable[[], None]] = []
         self._cups_callbacks: list[Callable[[], None]] = []
         # Called after a base recipe is (re-)read post-HD reset; consumers use
         # this to refresh cached attributes in select entities / attributes.
@@ -327,6 +336,24 @@ class MelittaBleClient(BleCommandsMixin, BleRecipesMixin, BleSettingsMixin):
     @property
     def cup_counters(self) -> dict[str, int]:
         return self._cup_counters
+
+    @property
+    def my_coffee_slots(self) -> list[dict[str, int]] | None:
+        """Cached MyCoffee slot params, or ``None`` if not yet read.
+
+        Indexed by slot number 0..N-1; each slot dict maps a param
+        name (currently only ``coffee_amount``) to the last value read
+        from the machine. A param key missing inside a slot dict means
+        the corresponding HR read failed.
+        """
+        return self._my_coffee_slots
+
+    def add_mycoffee_callback(self, callback: Callable[[], None]) -> None:
+        self._mycoffee_callbacks.append(callback)
+
+    def remove_mycoffee_callback(self, callback: Callable[[], None]) -> None:
+        if callback in self._mycoffee_callbacks:
+            self._mycoffee_callbacks.remove(callback)
 
     @property
     def profile_names(self) -> dict[int, str]:
@@ -887,10 +914,11 @@ class MelittaBleClient(BleCommandsMixin, BleRecipesMixin, BleSettingsMixin):
             return False
 
     async def _load_post_connect_data(self) -> None:
-        """Load cup counters and profile data after connect (non-blocking)."""
+        """Load cup counters, profile data and MyCoffee slot cache after connect."""
         try:
             await self.read_cup_counters()
             await self.read_profile_data()
+            await self.read_mycoffee_slots()
         except (BleakError, OSError, asyncio.TimeoutError):
             _LOGGER.debug("Error loading post-connect data", exc_info=True)
         except Exception:

--- a/custom_components/melitta_barista/sensor.py
+++ b/custom_components/melitta_barista/sensor.py
@@ -100,6 +100,20 @@ async def async_setup_entry(
         for descriptor in caps.stats:
             entities.append(BrandStatSensor(client, entry, name, descriptor))
 
+    # MyCoffee slot amount sensors — Nivona only, one per slot for the
+    # ``coffee_amount`` field (the most informative single number per
+    # slot). Populated by the post-connect bulk read in
+    # ``BleRecipesMixin.read_mycoffee_slots``; sensors register
+    # eagerly regardless of slot-enabled state and read from the cache
+    # once it's filled.
+    if (
+        caps is not None
+        and client.brand.brand_slug == "nivona"
+        and caps.my_coffee_slots > 0
+    ):
+        for slot in range(caps.my_coffee_slots):
+            entities.append(NivonaMyCoffeeAmountSensor(client, entry, name, slot))
+
     async_add_entities(entities)
 
 
@@ -430,3 +444,66 @@ class BrandStatSensor(_MelittaSensorBase):
             _LOGGER.debug(
                 "BrandStatSensor %s refresh failed", self._desc.key, exc_info=True,
             )
+
+
+class NivonaMyCoffeeAmountSensor(_MelittaSensorBase):
+    """Per-slot MyCoffee coffee_amount sensor (Nivona only, read-only).
+
+    Reads from the client's ``my_coffee_slots`` cache, which is filled
+    once per connect by ``BleRecipesMixin.read_mycoffee_slots``. Stays
+    ``unavailable`` until that first read completes.
+
+    First slice exposes only ``coffee_amount``; future PRs will expand
+    to other params (strength, milk amounts, enabled flag, etc.) and
+    add write support.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_native_unit_of_measurement = None  # raw byte value; vendor-specific scale
+    _attr_icon = "mdi:cup-outline"
+
+    def __init__(
+        self,
+        client: MelittaBleClient,
+        entry: ConfigEntry,
+        name: str,
+        slot: int,
+    ) -> None:
+        super().__init__(client, entry, name)
+        self._slot = slot
+        self._attr_name = f"MyCoffee slot {slot + 1} coffee amount"
+        self._attr_translation_key = "mycoffee_amount"
+        self._attr_translation_placeholders = {"slot": str(slot + 1)}
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._client.address}_mycoffee_slot_{self._slot}_coffee_amount"
+
+    @property
+    def available(self) -> bool:
+        slots = self._client.my_coffee_slots
+        return (
+            self._client.connected
+            and slots is not None
+            and self._slot < len(slots)
+            and "coffee_amount" in slots[self._slot]
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        slots = self._client.my_coffee_slots
+        if slots is None or self._slot >= len(slots):
+            return None
+        return slots[self._slot].get("coffee_amount")
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._client.add_mycoffee_callback(self._on_mycoffee_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        await super().async_will_remove_from_hass()
+        self._client.remove_mycoffee_callback(self._on_mycoffee_update)
+
+    @callback
+    def _on_mycoffee_update(self) -> None:
+        self.async_write_ha_state()

--- a/tests/test_ble_client.py
+++ b/tests/test_ble_client.py
@@ -3452,3 +3452,101 @@ class TestSettingsCoverageExtras:
         result = await client.write_alpha(310, "hello")
         assert result is True
         client.start_polling.assert_called_once_with(interval=client._poll_interval)
+
+
+# ---------------------------------------------------------------------------
+# read_mycoffee_slots — Nivona MyCoffee slot bulk read (PR E)
+# ---------------------------------------------------------------------------
+
+class TestReadMyCoffeeSlots:
+    """Bulk-read MyCoffee slot params on connect for Nivona families.
+
+    Reads HR registers `MY_COFFEE_BASE_REGISTER + slot*STRIDE + offset`
+    for each slot 0..my_coffee_slots-1 using the family-specific
+    layout to know which offsets to fetch. Cached on the client and
+    surfaced via the `my_coffee_slots` property.
+
+    First slice exposes only `coffee_amount` per slot.
+    """
+
+    async def test_returns_false_when_not_connected(self):
+        client = MelittaBleClient("AA:BB:CC:DD:EE:FF")
+        assert await client.read_mycoffee_slots() is False
+
+    async def test_returns_false_for_melitta(self, mock_bleak_client):
+        """Melitta has its own MyCoffee scheme (DirectKey); this method
+        is Nivona-only and must no-op on Melitta brand."""
+        from custom_components.melitta_barista.brands.melitta import MelittaProfile
+        client = _make_connected_client(mock_bleak_client, brand=MelittaProfile())
+        assert await client.read_mycoffee_slots() is False
+
+    async def test_returns_false_without_capabilities(self, mock_bleak_client):
+        """If capability resolution didn't finish, skip the bulk read."""
+        from custom_components.melitta_barista.brands.nivona import NivonaProfile
+        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
+        client._capabilities = None
+        assert await client.read_mycoffee_slots() is False
+
+    async def test_reads_coffee_amount_for_each_slot(self, mock_bleak_client):
+        """For a family with N slots, calls read_numerical N times at
+        the correct coffee_amount register and caches each value.
+        """
+        from custom_components.melitta_barista.brands.nivona import (
+            MY_COFFEE_BASE_REGISTER, MY_COFFEE_SLOT_STRIDE, NivonaProfile,
+            mycoffee_layout, mycoffee_register,
+        )
+        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
+        # 8000 family has 9 MyCoffee slots and a `coffee_amount_offset = 8`.
+        client._capabilities = NivonaProfile().capabilities_for_model(
+            "NIVONA-8101000000-----",
+        )
+        assert client._capabilities is not None
+        assert client._capabilities.my_coffee_slots == 9
+        layout = mycoffee_layout(client._capabilities.family_key)
+        assert layout is not None
+        assert layout.coffee_amount_offset == 8
+
+        # Each slot returns a distinct value so we can verify the
+        # register cycle visited every slot exactly once.
+        slots_seen: list[int] = []
+
+        async def fake_read(_write, register: int):
+            # Recover slot index from register layout.
+            slot = (register - MY_COFFEE_BASE_REGISTER) // MY_COFFEE_SLOT_STRIDE
+            slots_seen.append(slot)
+            return 100 + slot  # 100, 101, 102, ...
+
+        client._protocol.read_numerical = fake_read
+
+        result = await client.read_mycoffee_slots()
+
+        assert result is True
+        assert sorted(slots_seen) == list(range(9))
+        cached = client.my_coffee_slots
+        assert cached is not None
+        assert len(cached) == 9
+        for slot in range(9):
+            assert cached[slot]["coffee_amount"] == 100 + slot
+
+    async def test_partial_failures_swallowed(self, mock_bleak_client):
+        """One slot's HR read failing must not abort the rest."""
+        from custom_components.melitta_barista.brands.nivona import NivonaProfile
+        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
+        client._capabilities = NivonaProfile().capabilities_for_model(
+            "NIVONA-8101000000-----",
+        )
+
+        async def flaky_read(_write, register: int):
+            # Slot 3 (register 20308) errors out.
+            if register == 20308:
+                raise BleakError("simulated")
+            return 42
+
+        client._protocol.read_numerical = flaky_read
+        assert await client.read_mycoffee_slots() is True
+        cached = client.my_coffee_slots
+        assert cached is not None
+        assert "coffee_amount" not in cached[3]
+        # Other slots still cached
+        for slot in (0, 1, 2, 4, 5, 6, 7, 8):
+            assert cached[slot]["coffee_amount"] == 42

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -211,3 +211,45 @@ async def test_total_cups_sensor_still_created_for_melitta(
     assert any("total_cups" in eid for eid in sensor_ids), (
         f"Total Cups sensor should still register for Melitta; saw: {sensor_ids}"
     )
+
+
+async def test_mycoffee_amount_sensors_registered_for_nivona_8000(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Nivona 8000 family with 9 MyCoffee slots → 9 amount sensors."""
+    client = _mock_client()  # default mock fits — we override below
+    client.brand.brand_slug = "nivona"
+    client.brand.brand_name = "Nivona"
+    client.brand.supported_extensions = frozenset()
+    caps = MagicMock()
+    caps.family_key = "8000"
+    caps.my_coffee_slots = 9
+    caps.stats = ()
+    client.capabilities = caps
+    client.my_coffee_slots = None
+    await _setup_integration(hass, mock_entry, client)
+
+    mycoffee_sensors = [
+        s for s in hass.states.async_all("sensor")
+        if "mycoffee_slot_" in s.entity_id and "_coffee_amount" in s.entity_id
+    ]
+    assert len(mycoffee_sensors) == 9, (
+        f"Expected 9 mycoffee amount sensors for 8000 family; "
+        f"got {[s.entity_id for s in mycoffee_sensors]}"
+    )
+
+
+async def test_mycoffee_sensors_not_registered_for_melitta(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Melitta has its own MyCoffee scheme; no per-slot amount sensors register."""
+    client = _mock_client()  # default brand = melitta
+    await _setup_integration(hass, mock_entry, client)
+
+    mycoffee_sensors = [
+        s for s in hass.states.async_all("sensor")
+        if "mycoffee_slot_" in s.entity_id
+    ]
+    assert mycoffee_sensors == [], (
+        f"Melitta must not get Nivona mycoffee sensors; got {mycoffee_sensors}"
+    )


### PR DESCRIPTION
## Summary

PR E from the Tier-2 batch — first slice of Gap #6 (MyCoffee CRUD).

Bulk-reads each Nivona MyCoffee slot's `coffee_amount` register on connect and exposes the cached values as per-slot diagnostic sensors. Foundation for future MyCoffee param expansion (strength, milk amounts, etc.) and write support.

### Pipeline

```
connect → _load_post_connect_data
  → read_cup_counters (existing)
  → read_profile_data (existing)
  → read_mycoffee_slots (new)   ← Nivona only
      → for slot in 0..N-1:
          HR @ MY_COFFEE_BASE_REGISTER + slot*100 + coffee_amount_offset
        cache → MelittaBleClient.my_coffee_slots
        notify mycoffee_callbacks
```

### Sensors

- `NivonaMyCoffeeAmountSensor` per slot — `EntityCategory.DIAGNOSTIC`.
- Slot count comes from `_capabilities.my_coffee_slots`. For NIVO 8101 with 9 slots → 9 sensors; for NICR 1040 with 18 slots → 18 sensors.
- Sensors register eagerly at setup; stay `unavailable` until the first bulk read completes.

### What's intentionally NOT in this PR

- Other MyCoffee params (strength, milk amounts, temperature, profile, enabled flag) — only `coffee_amount` for the first slice.
- Write support — read-only here.
- Brew-by-MyCoffee-slot — needs the `first_mycoffee_selector` constant from PR C, but the button entity isn't wired up yet.
- Name editing via HB — out of scope until family-aware encoding lands.

These all live in the broader MyCoffee CRUD plan; this PR validates the read pipeline end-to-end.

### Tests

- 5 new tests in `tests/test_ble_client.py::TestReadMyCoffeeSlots` — no-op branches (not connected, wrong brand, no caps), full read cycle visits every slot, partial HR failures don't abort.
- 2 new tests in `tests/test_sensor.py` — sensor registration count matches `my_coffee_slots` on Nivona, no registration on Melitta.
- Full suite: 979 passed (was 972 on v0.77.1).

### Release

This PR does **not** tag a release — bundling with PR D (factory-reset buttons, already on main) into a single 0.78.0 release once the batch is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)