### PR TITLE
feat: expand MyCoffee bulk read to all four amount params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
   Both available on families 600 / 700 / 79x / 900 / 900-light / 1030 / 1040. Hidden (entity stays unavailable) on NIVO 8000 — the vendor app doesn't expose factory-reset there either. Melitta brand is unaffected — these buttons don't register for `brand_slug == "melitta"`.
 - **Generic `execute_command(command_id)`** path on `EugsterProtocol` and `BleCommandsMixin` (as `execute_he_command`). Builds an 18-byte HE payload with `command_id` BE in `[0:2]`, sent under the existing `HE` opcode; the firmware distinguishes brew from "execute command" by payload shape.
-- **MyCoffee slot bulk read (Nivona)**. On every connect, after capability resolution, the client now reads each MyCoffee slot's `coffee_amount` register and caches the result on `MelittaBleClient.my_coffee_slots`. Per-slot `MyCoffee slot N coffee amount` diagnostic sensors expose the cached values; sensors stay `unavailable` until the first bulk read completes. Foundation for the broader MyCoffee CRUD work — write support and additional params will follow.
+- **MyCoffee slot bulk read (Nivona)**. On every connect, after capability resolution, the client now reads each MyCoffee slot's amount registers (`coffee_amount` / `water_amount` / `milk_amount` / `milk_foam_amount` — only those whose offset is defined in the family's MyCoffee layout, so 600 family for example skips `milk_amount`) and caches the result on `MelittaBleClient.my_coffee_slots`. Per-(slot, param) `MyCoffee slot N <param>` diagnostic sensors expose the cached values; sensors stay `unavailable` until the first bulk read completes. For NIVO 8000 with 9 slots that's 36 sensors (9 × 4 amounts); for NICR 1040 with 18 slots it's 72. All under the `DIAGNOSTIC` category. Foundation for the broader MyCoffee CRUD work — write support and code-style params (strength, temperature, enabled flag, profile) will follow in later releases.
 
 ### Tests
 - 8 new tests for the factory-reset path (`tests/test_protocol.py::TestExecuteCommand` + `tests/test_button.py`).
-- 5 new tests for MyCoffee bulk read (`tests/test_ble_client.py::TestReadMyCoffeeSlots`) + 2 sensor-registration tests (`tests/test_sensor.py`).
-- Full suite: 979 passed (was 964 on v0.77.1).
+- 6 new tests for MyCoffee bulk read (`tests/test_ble_client.py::TestReadMyCoffeeSlots`) + 3 sensor-registration tests (`tests/test_sensor.py`).
+- Full suite: 981 passed (was 964 on v0.77.1).
 
 ## [0.77.1] — 2026-05-28
 

--- a/custom_components/melitta_barista/_ble_recipes.py
+++ b/custom_components/melitta_barista/_ble_recipes.py
@@ -31,6 +31,20 @@ from .protocol import MachineRecipe, RecipeComponent
 _LOGGER = logging.getLogger("melitta_barista")
 
 
+# Param keys (and `<key>_offset` attribute names on RecipeFieldLayout)
+# that the MyCoffee bulk-read pulls per slot. Single source of truth
+# also used by `sensor.py` to decide which sensors to register.
+# Only "amount" params for now — the rest (strength / temperature /
+# enabled flag / profile / two_cups) will follow in later PRs once we
+# decide on entity shapes for them.
+_MYCOFFEE_AMOUNT_PARAMS: tuple[str, ...] = (
+    "coffee_amount",
+    "water_amount",
+    "milk_amount",
+    "milk_foam_amount",
+)
+
+
 class BleRecipesMixin(_MixinBase):
     """Mixin providing recipe, profile, and cup counter operations."""
 
@@ -467,7 +481,7 @@ class BleRecipesMixin(_MixinBase):
         return True
 
     async def read_mycoffee_slots(self) -> bool:
-        """Bulk-read the current MyCoffee slot params from the machine.
+        """Bulk-read MyCoffee slot params (4 amounts) from the machine.
 
         Nivona-only: Melitta has its own MyCoffee scheme that goes
         through DirectKey IDs and doesn't share these registers. For
@@ -477,9 +491,12 @@ class BleRecipesMixin(_MixinBase):
         sub-register; the layout comes from
         ``brand.mycoffee_layout(family_key)``.
 
-        Currently reads only the ``coffee_amount`` field per slot (the
-        most informative single number per slot). Result is cached on
-        the client at ``_my_coffee_slots`` and surfaced through the
+        Reads ``coffee_amount`` / ``water_amount`` / ``milk_amount`` /
+        ``milk_foam_amount`` per slot — only the params whose
+        ``<param>_offset`` is defined for the family layout (the 600
+        family for example has no ``milk_amount_offset``, only
+        ``milk_foam_amount_offset``). Result is cached on the client at
+        ``_my_coffee_slots`` and surfaced through the
         ``my_coffee_slots`` property. Returns ``True`` if at least the
         cache slot list was initialised (even if some individual HR
         reads failed), ``False`` if the call was skipped (wrong brand /
@@ -500,26 +517,36 @@ class BleRecipesMixin(_MixinBase):
         )  # noqa: PLC0415
 
         layout = mycoffee_layout(caps.family_key)
-        if layout is None or layout.coffee_amount_offset is None:
+        if layout is None:
             return False
+
+        # (param_key, layout-attr) pairs — single source of truth shared
+        # with sensor.py via `_MYCOFFEE_AMOUNT_PARAMS`.
+        param_specs = [
+            (param_key, getattr(layout, f"{param_key}_offset"))
+            for param_key in _MYCOFFEE_AMOUNT_PARAMS
+        ]
 
         slots: list[dict[str, int]] = [
             {} for _ in range(caps.my_coffee_slots)
         ]
         for slot in range(caps.my_coffee_slots):
-            register = mycoffee_register(slot, layout.coffee_amount_offset)
-            try:
-                val = await self._protocol.read_numerical(
-                    self._write_ble, register,
-                )
-            except (BleakError, OSError, asyncio.TimeoutError):
-                _LOGGER.debug(
-                    "MyCoffee read failed for slot %d (register %d)",
-                    slot, register,
-                )
-                continue
-            if val is not None:
-                slots[slot]["coffee_amount"] = val
+            for param_key, offset in param_specs:
+                if offset is None:
+                    continue
+                register = mycoffee_register(slot, offset)
+                try:
+                    val = await self._protocol.read_numerical(
+                        self._write_ble, register,
+                    )
+                except (BleakError, OSError, asyncio.TimeoutError):
+                    _LOGGER.debug(
+                        "MyCoffee read failed for slot %d %s (register %d)",
+                        slot, param_key, register,
+                    )
+                    continue
+                if val is not None:
+                    slots[slot][param_key] = val
 
         self._my_coffee_slots = slots
         _LOGGER.debug("MyCoffee slot cache populated: %s", slots)

--- a/custom_components/melitta_barista/sensor.py
+++ b/custom_components/melitta_barista/sensor.py
@@ -100,19 +100,31 @@ async def async_setup_entry(
         for descriptor in caps.stats:
             entities.append(BrandStatSensor(client, entry, name, descriptor))
 
-    # MyCoffee slot amount sensors — Nivona only, one per slot for the
-    # ``coffee_amount`` field (the most informative single number per
-    # slot). Populated by the post-connect bulk read in
-    # ``BleRecipesMixin.read_mycoffee_slots``; sensors register
-    # eagerly regardless of slot-enabled state and read from the cache
-    # once it's filled.
+    # MyCoffee slot amount sensors — Nivona only. For each slot 0..N-1,
+    # register one sensor per amount param (coffee / water / milk /
+    # milk_foam) that the family's MyCoffee layout actually exposes
+    # (the 600 family for example has no ``milk_amount_offset``). The
+    # cache is populated by the post-connect bulk read in
+    # ``BleRecipesMixin.read_mycoffee_slots``; sensors stay
+    # ``unavailable`` until the first read completes.
     if (
         caps is not None
         and client.brand.brand_slug == "nivona"
         and caps.my_coffee_slots > 0
     ):
-        for slot in range(caps.my_coffee_slots):
-            entities.append(NivonaMyCoffeeAmountSensor(client, entry, name, slot))
+        from .brands.nivona import mycoffee_layout  # noqa: PLC0415
+        from ._ble_recipes import _MYCOFFEE_AMOUNT_PARAMS  # noqa: PLC0415
+        layout = mycoffee_layout(caps.family_key)
+        if layout is not None:
+            for slot in range(caps.my_coffee_slots):
+                for param_key in _MYCOFFEE_AMOUNT_PARAMS:
+                    if getattr(layout, f"{param_key}_offset") is None:
+                        continue
+                    entities.append(
+                        NivonaMyCoffeeAmountSensor(
+                            client, entry, name, slot, param_key,
+                        )
+                    )
 
     async_add_entities(entities)
 
@@ -447,20 +459,29 @@ class BrandStatSensor(_MelittaSensorBase):
 
 
 class NivonaMyCoffeeAmountSensor(_MelittaSensorBase):
-    """Per-slot MyCoffee coffee_amount sensor (Nivona only, read-only).
+    """Per-(slot, param) MyCoffee amount sensor for Nivona (read-only).
 
     Reads from the client's ``my_coffee_slots`` cache, which is filled
     once per connect by ``BleRecipesMixin.read_mycoffee_slots``. Stays
     ``unavailable`` until that first read completes.
 
-    First slice exposes only ``coffee_amount``; future PRs will expand
-    to other params (strength, milk amounts, enabled flag, etc.) and
-    add write support.
+    Currently exposes the four "amount" params per slot
+    (coffee / water / milk / milk_foam) — only those whose offset is
+    defined in the family's MyCoffee layout. Future PRs will add
+    strength / temperature / enabled flag and write support.
     """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = None  # raw byte value; vendor-specific scale
     _attr_icon = "mdi:cup-outline"
+
+    # Human-readable suffix per param.
+    _LABELS = {
+        "coffee_amount": "coffee amount",
+        "water_amount": "water amount",
+        "milk_amount": "milk amount",
+        "milk_foam_amount": "milk foam amount",
+    }
 
     def __init__(
         self,
@@ -468,16 +489,21 @@ class NivonaMyCoffeeAmountSensor(_MelittaSensorBase):
         entry: ConfigEntry,
         name: str,
         slot: int,
+        param_key: str,
     ) -> None:
         super().__init__(client, entry, name)
         self._slot = slot
-        self._attr_name = f"MyCoffee slot {slot + 1} coffee amount"
-        self._attr_translation_key = "mycoffee_amount"
+        self._param_key = param_key
+        label = self._LABELS.get(param_key, param_key.replace("_", " "))
+        self._attr_name = f"MyCoffee slot {slot + 1} {label}"
+        self._attr_translation_key = f"mycoffee_{param_key}"
         self._attr_translation_placeholders = {"slot": str(slot + 1)}
 
     @property
     def unique_id(self) -> str:
-        return f"{self._client.address}_mycoffee_slot_{self._slot}_coffee_amount"
+        return (
+            f"{self._client.address}_mycoffee_slot_{self._slot}_{self._param_key}"
+        )
 
     @property
     def available(self) -> bool:
@@ -486,7 +512,7 @@ class NivonaMyCoffeeAmountSensor(_MelittaSensorBase):
             self._client.connected
             and slots is not None
             and self._slot < len(slots)
-            and "coffee_amount" in slots[self._slot]
+            and self._param_key in slots[self._slot]
         )
 
     @property
@@ -494,7 +520,7 @@ class NivonaMyCoffeeAmountSensor(_MelittaSensorBase):
         slots = self._client.my_coffee_slots
         if slots is None or self._slot >= len(slots):
             return None
-        return slots[self._slot].get("coffee_amount")
+        return slots[self._slot].get(self._param_key)
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()

--- a/tests/test_ble_client.py
+++ b/tests/test_ble_client.py
@@ -3487,46 +3487,7 @@ class TestReadMyCoffeeSlots:
         client._capabilities = None
         assert await client.read_mycoffee_slots() is False
 
-    async def test_reads_coffee_amount_for_each_slot(self, mock_bleak_client):
-        """For a family with N slots, calls read_numerical N times at
-        the correct coffee_amount register and caches each value.
-        """
-        from custom_components.melitta_barista.brands.nivona import (
-            MY_COFFEE_BASE_REGISTER, MY_COFFEE_SLOT_STRIDE, NivonaProfile,
-            mycoffee_layout, mycoffee_register,
-        )
-        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
-        # 8000 family has 9 MyCoffee slots and a `coffee_amount_offset = 8`.
-        client._capabilities = NivonaProfile().capabilities_for_model(
-            "NIVONA-8101000000-----",
-        )
-        assert client._capabilities is not None
-        assert client._capabilities.my_coffee_slots == 9
-        layout = mycoffee_layout(client._capabilities.family_key)
-        assert layout is not None
-        assert layout.coffee_amount_offset == 8
-
-        # Each slot returns a distinct value so we can verify the
-        # register cycle visited every slot exactly once.
-        slots_seen: list[int] = []
-
-        async def fake_read(_write, register: int):
-            # Recover slot index from register layout.
-            slot = (register - MY_COFFEE_BASE_REGISTER) // MY_COFFEE_SLOT_STRIDE
-            slots_seen.append(slot)
-            return 100 + slot  # 100, 101, 102, ...
-
-        client._protocol.read_numerical = fake_read
-
-        result = await client.read_mycoffee_slots()
-
-        assert result is True
-        assert sorted(slots_seen) == list(range(9))
-        cached = client.my_coffee_slots
-        assert cached is not None
-        assert len(cached) == 9
-        for slot in range(9):
-            assert cached[slot]["coffee_amount"] == 100 + slot
+    
 
     async def test_partial_failures_swallowed(self, mock_bleak_client):
         """One slot's HR read failing must not abort the rest."""
@@ -3550,3 +3511,71 @@ class TestReadMyCoffeeSlots:
         # Other slots still cached
         for slot in (0, 1, 2, 4, 5, 6, 7, 8):
             assert cached[slot]["coffee_amount"] == 42
+
+
+    async def test_reads_all_four_amounts_per_slot(self, mock_bleak_client):
+        """8000 family layout exposes coffee/water/milk/milk_foam amounts.
+
+        Bulk read should fetch all four per slot, indexed by the
+        param key. Offsets used: 8 (coffee), 9 (water), 10 (milk),
+        11 (milk_foam).
+        """
+        from custom_components.melitta_barista.brands.nivona import (
+            MY_COFFEE_BASE_REGISTER, MY_COFFEE_SLOT_STRIDE, NivonaProfile,
+        )
+        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
+        client._capabilities = NivonaProfile().capabilities_for_model(
+            "NIVONA-8101000000-----",
+        )
+        assert client._capabilities.my_coffee_slots == 9
+
+        # Encode (slot, offset) → distinct value so we can verify the
+        # cycle visited every (slot, param) pair exactly once.
+        async def fake_read(_write, register: int):
+            slot = (register - MY_COFFEE_BASE_REGISTER) // MY_COFFEE_SLOT_STRIDE
+            offset = (register - MY_COFFEE_BASE_REGISTER) % MY_COFFEE_SLOT_STRIDE
+            return slot * 100 + offset
+
+        client._protocol.read_numerical = fake_read
+
+        result = await client.read_mycoffee_slots()
+        assert result is True
+
+        cached = client.my_coffee_slots
+        assert cached is not None
+        assert len(cached) == 9
+        for slot in range(9):
+            # Each amount has a distinct register offset on 8000 family
+            # (8, 9, 10, 11). The fake_read encoding mirrors that.
+            assert cached[slot]["coffee_amount"] == slot * 100 + 8
+            assert cached[slot]["water_amount"] == slot * 100 + 9
+            assert cached[slot]["milk_amount"] == slot * 100 + 10
+            assert cached[slot]["milk_foam_amount"] == slot * 100 + 11
+
+    async def test_skips_params_missing_from_layout(self, mock_bleak_client):
+        """600 family has milk_foam_amount but no milk_amount offset —
+        the bulk reader must not invent registers that the layout
+        doesn't declare.
+        """
+        from custom_components.melitta_barista.brands.nivona import NivonaProfile
+        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
+        # NICR 660 → family "600". 600 layout has no milk_amount_offset
+        # (only milk_foam_amount_offset).
+        client._capabilities = NivonaProfile().capabilities_for_model(
+            "NIVONA-6605730710-----",
+        )
+        assert client._capabilities is not None
+        assert client._capabilities.family_key == "600"
+
+        async def echo(_write, register: int):
+            return register  # any non-None value
+
+        client._protocol.read_numerical = echo
+        await client.read_mycoffee_slots()
+        cached = client.my_coffee_slots
+        assert cached is not None
+        assert "milk_amount" not in cached[0], (
+            "milk_amount must not be read on 600 family — layout has no offset"
+        )
+        # milk_foam_amount IS in 600 layout (offset 11), so it must be present.
+        assert "milk_foam_amount" in cached[0]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -216,7 +216,11 @@ async def test_total_cups_sensor_still_created_for_melitta(
 async def test_mycoffee_amount_sensors_registered_for_nivona_8000(
     hass: HomeAssistant, mock_entry: MockConfigEntry
 ) -> None:
-    """Nivona 8000 family with 9 MyCoffee slots → 9 amount sensors."""
+    """Nivona 8000 family — 9 slots × 4 amounts = 36 sensors.
+
+    Layout offsets for 8000 family include all four amounts
+    (coffee / water / milk / milk_foam), so all four register per slot.
+    """
     client = _mock_client()  # default mock fits — we override below
     client.brand.brand_slug = "nivona"
     client.brand.brand_name = "Nivona"
@@ -231,11 +235,46 @@ async def test_mycoffee_amount_sensors_registered_for_nivona_8000(
 
     mycoffee_sensors = [
         s for s in hass.states.async_all("sensor")
-        if "mycoffee_slot_" in s.entity_id and "_coffee_amount" in s.entity_id
+        if "mycoffee_slot_" in s.entity_id
     ]
-    assert len(mycoffee_sensors) == 9, (
-        f"Expected 9 mycoffee amount sensors for 8000 family; "
-        f"got {[s.entity_id for s in mycoffee_sensors]}"
+    assert len(mycoffee_sensors) == 36, (
+        f"Expected 36 mycoffee amount sensors for 8000 family (9 slots × 4 amounts); "
+        f"got {len(mycoffee_sensors)}: {[s.entity_id for s in mycoffee_sensors]}"
+    )
+    # Each amount param appears once per slot.
+    for param in ("coffee_amount", "water_amount", "milk_amount", "milk_foam_amount"):
+        per_param = [s for s in mycoffee_sensors if param in s.entity_id]
+        assert len(per_param) == 9, (
+            f"Expected 9 sensors for {param}; got {len(per_param)}"
+        )
+
+
+async def test_mycoffee_skips_params_missing_from_layout_600(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """600 family has no `milk_amount_offset` in its MyCoffee layout —
+    the sensor must not register for that param on slots 0..N-1.
+    """
+    client = _mock_client()
+    client.brand.brand_slug = "nivona"
+    client.brand.brand_name = "Nivona"
+    client.brand.supported_extensions = frozenset()
+    caps = MagicMock()
+    caps.family_key = "600"
+    caps.my_coffee_slots = 1  # NICR 660 has 1 MyCoffee slot
+    caps.stats = ()
+    client.capabilities = caps
+    client.my_coffee_slots = None
+    await _setup_integration(hass, mock_entry, client)
+
+    sensor_ids = [s.entity_id for s in hass.states.async_all("sensor")]
+    # 600 layout has coffee_amount + water_amount + milk_foam_amount
+    # but NO milk_amount.
+    assert any("mycoffee_slot_1_coffee_amount" in eid for eid in sensor_ids), sensor_ids
+    assert any("mycoffee_slot_1_water_amount" in eid for eid in sensor_ids), sensor_ids
+    assert any("mycoffee_slot_1_milk_foam_amount" in eid for eid in sensor_ids), sensor_ids
+    assert not any("mycoffee_slot_1_milk_amount" in eid for eid in sensor_ids), (
+        f"milk_amount sensor must not exist for 600 family; saw: {sensor_ids}"
     )
 
 


### PR DESCRIPTION
## Summary

Follow-up to PR E: expands the MyCoffee bulk-read from a single param (`coffee_amount`) to all four amount params per slot (`coffee_amount` / `water_amount` / `milk_amount` / `milk_foam_amount`).

### Layout-aware gating

For each (slot, param) pair, the reader checks the family's MyCoffee layout for a `<param>_offset` attribute. If the offset is `None` (e.g. 600 family has no `milk_amount_offset`, only `milk_foam_amount_offset`), the read is skipped and the sensor isn't even registered. So no spurious "unavailable" sensors for params the hardware doesn't expose.

Per-family sensor counts:

| Family | Slots | Amounts exposed | Sensors |
|---|---|---|---|
| 8000 (NIVO 8101 etc.) | 9 | 4 | 36 |
| 1030 / 1040 | 18 | 4 | 72 |
| 700 / 79x | 1–5 (per model) | 4 | up to 20 |
| 600 | 1–5 (per model) | 3 (no milk_amount) | up to 15 |
| 900 / 900-light | 9 | 4 | 36 |

All under `EntityCategory.DIAGNOSTIC` — they're tucked away in HA's diagnostic group, not in the main entity list.

### Architecture note

The new `_MYCOFFEE_AMOUNT_PARAMS` tuple in `_ble_recipes.py` is the single source of truth for which params get bulk-read + exposed. Adding code-style params (strength / temperature / enabled / profile) in a later PR is a one-line addition there + new descriptor in `sensor.py`. Same shape — no refactor needed.

### Tests

- 2 new bulk-read tests:
  - `test_reads_all_four_amounts_per_slot` (8000 family — all 4 offsets present, full cycle visits 9 × 4 = 36 register reads).
  - `test_skips_params_missing_from_layout` (600 family — `milk_amount` skipped, `milk_foam_amount` present).
- 1 new sensor test: 600-family layout drops `milk_amount` sensor.
- Removed the now-redundant single-param test.
- Full suite: **981 passed** (was 979 on the previous PR-E commit).

### Release

This PR does **not** tag a release — bundling with PR D (factory-reset buttons) and PR E (MyCoffee bulk read base) into a single **0.78.0** release once the batch is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)