### PR TITLE
feat: expose MyCoffee enabled / strength / temperature alongside amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,22 @@ All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
   Both available on families 600 / 700 / 79x / 900 / 900-light / 1030 / 1040. Hidden (entity stays unavailable) on NIVO 8000 — the vendor app doesn't expose factory-reset there either. Melitta brand is unaffected — these buttons don't register for `brand_slug == "melitta"`.
 - **Generic `execute_command(command_id)`** path on `EugsterProtocol` and `BleCommandsMixin` (as `execute_he_command`). Builds an 18-byte HE payload with `command_id` BE in `[0:2]`, sent under the existing `HE` opcode; the firmware distinguishes brew from "execute command" by payload shape.
-- **MyCoffee slot bulk read (Nivona)**. On every connect, after capability resolution, the client now reads each MyCoffee slot's amount registers (`coffee_amount` / `water_amount` / `milk_amount` / `milk_foam_amount` — only those whose offset is defined in the family's MyCoffee layout, so 600 family for example skips `milk_amount`) and caches the result on `MelittaBleClient.my_coffee_slots`. Per-(slot, param) `MyCoffee slot N <param>` diagnostic sensors expose the cached values; sensors stay `unavailable` until the first bulk read completes. For NIVO 8000 with 9 slots that's 36 sensors (9 × 4 amounts); for NICR 1040 with 18 slots it's 72. All under the `DIAGNOSTIC` category. Foundation for the broader MyCoffee CRUD work — write support and code-style params (strength, temperature, enabled flag, profile) will follow in later releases.
+- **MyCoffee slot bulk read (Nivona)**. On every connect, after capability resolution, the client now reads each MyCoffee slot's params and caches them on `MelittaBleClient.my_coffee_slots`. Per-(slot, param) `MyCoffee slot N <param>` diagnostic sensors expose the cached values; sensors stay `unavailable` until the first bulk read completes.
+
+  Params read per slot, gated on whether the family's MyCoffee layout defines the corresponding offset:
+  - `coffee_amount`, `water_amount`, `milk_amount`, `milk_foam_amount` — the four fluid amounts. 600 family has only three (no `milk_amount_offset`); 700 / 79x / 8000 / 900 / 900-light / 1030 / 1040 have all four.
+  - `enabled` (0/1 flag) — whether the slot is "armed". Present on every family.
+  - `strength` (code 1..N) — bean-strength selector for the slot. Present on every family.
+  - `temperature` (code 0..3) — brew-temperature selector. Present only on single-byte-temperature families (600 / 700 / 79x / 8000); the 900 / 1030 / 1040 layouts use per-fluid temperature offsets and skip this param.
+
+  Sensor counts per family: NIVO 8000 → 9 slots × 7 params = 63 sensors; NICR 1040 → 18 × 6 = 108; NICR 600 → up to 5 × 6 = 30. All under `EntityCategory.DIAGNOSTIC` — they sit in HA's diagnostic group, not the main entity list.
+
+  Foundation for the broader MyCoffee CRUD work — write support and code-style params (profile, two_cups, per-fluid temperatures) will follow in later releases.
 
 ### Tests
 - 8 new tests for the factory-reset path (`tests/test_protocol.py::TestExecuteCommand` + `tests/test_button.py`).
-- 6 new tests for MyCoffee bulk read (`tests/test_ble_client.py::TestReadMyCoffeeSlots`) + 3 sensor-registration tests (`tests/test_sensor.py`).
-- Full suite: 981 passed (was 964 on v0.77.1).
+- 6 new tests for MyCoffee bulk read (`tests/test_ble_client.py::TestReadMyCoffeeSlots`) + 4 sensor-registration tests (`tests/test_sensor.py`).
+- Full suite: 982 passed (was 964 on v0.77.1).
 
 ## [0.77.1] — 2026-05-28
 

--- a/custom_components/melitta_barista/_ble_recipes.py
+++ b/custom_components/melitta_barista/_ble_recipes.py
@@ -33,15 +33,29 @@ _LOGGER = logging.getLogger("melitta_barista")
 
 # Param keys (and `<key>_offset` attribute names on RecipeFieldLayout)
 # that the MyCoffee bulk-read pulls per slot. Single source of truth
-# also used by `sensor.py` to decide which sensors to register.
-# Only "amount" params for now — the rest (strength / temperature /
-# enabled flag / profile / two_cups) will follow in later PRs once we
-# decide on entity shapes for them.
+# also used by `sensor.py` to decide which sensors to register. Only
+# params present in the family layout are read / exposed — see
+# `mycoffee_layout()` for per-family offsets. The exposed set is
+# intentionally narrow:
+#
+# - 4 amounts (coffee / water / milk / milk_foam): the most informative
+#   numeric params per slot. The 900 / 1030 / 1040 families that use
+#   per-fluid temperature offsets instead of a single `temperature`
+#   one still expose all four amounts.
+# - enabled (0/1 flag): tells the user whether the slot is "armed" —
+#   future write-side gating can use this.
+# - strength (code 0..N): bean strength selector inside the slot.
+# - temperature (code 0..3): single-byte families (600/700/79x/8000)
+#   have one offset; multi-fluid families (900/1030/1040) have none
+#   and the param is silently skipped.
 _MYCOFFEE_AMOUNT_PARAMS: tuple[str, ...] = (
     "coffee_amount",
     "water_amount",
     "milk_amount",
     "milk_foam_amount",
+    "enabled",
+    "strength",
+    "temperature",
 )
 
 

--- a/custom_components/melitta_barista/sensor.py
+++ b/custom_components/melitta_barista/sensor.py
@@ -473,14 +473,26 @@ class NivonaMyCoffeeAmountSensor(_MelittaSensorBase):
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = None  # raw byte value; vendor-specific scale
-    _attr_icon = "mdi:cup-outline"
 
-    # Human-readable suffix per param.
+    # Human-readable suffix per param + an icon hint.
     _LABELS = {
         "coffee_amount": "coffee amount",
         "water_amount": "water amount",
         "milk_amount": "milk amount",
         "milk_foam_amount": "milk foam amount",
+        "enabled": "enabled",
+        "strength": "strength",
+        "temperature": "temperature",
+    }
+
+    _ICONS = {
+        "coffee_amount": "mdi:cup-outline",
+        "water_amount": "mdi:cup-water",
+        "milk_amount": "mdi:bottle-tonic-plus-outline",
+        "milk_foam_amount": "mdi:bottle-tonic-outline",
+        "enabled": "mdi:check-circle-outline",
+        "strength": "mdi:weight",
+        "temperature": "mdi:thermometer",
     }
 
     def __init__(
@@ -498,6 +510,7 @@ class NivonaMyCoffeeAmountSensor(_MelittaSensorBase):
         self._attr_name = f"MyCoffee slot {slot + 1} {label}"
         self._attr_translation_key = f"mycoffee_{param_key}"
         self._attr_translation_placeholders = {"slot": str(slot + 1)}
+        self._attr_icon = self._ICONS.get(param_key, "mdi:cup-outline")
 
     @property
     def unique_id(self) -> str:

--- a/tests/test_ble_client.py
+++ b/tests/test_ble_client.py
@@ -3514,11 +3514,11 @@ class TestReadMyCoffeeSlots:
 
 
     async def test_reads_all_four_amounts_per_slot(self, mock_bleak_client):
-        """8000 family layout exposes coffee/water/milk/milk_foam amounts.
+        """8000 family layout exposes 4 amounts + enabled / strength / temperature.
 
-        Bulk read should fetch all four per slot, indexed by the
-        param key. Offsets used: 8 (coffee), 9 (water), 10 (milk),
-        11 (milk_foam).
+        Bulk read should fetch each param via a separate HR register
+        derived from the slot's `MY_COFFEE_BASE_REGISTER + N*100 + offset`
+        and key the result by the param name in the cache.
         """
         from custom_components.melitta_barista.brands.nivona import (
             MY_COFFEE_BASE_REGISTER, MY_COFFEE_SLOT_STRIDE, NivonaProfile,
@@ -3544,13 +3544,24 @@ class TestReadMyCoffeeSlots:
         cached = client.my_coffee_slots
         assert cached is not None
         assert len(cached) == 9
+
+        # 8000 family offsets: enabled=0, strength=4, temperature=6,
+        # coffee_amount=8, water_amount=9, milk_amount=10, milk_foam_amount=11.
+        expected = {
+            "enabled": 0,
+            "strength": 4,
+            "temperature": 6,
+            "coffee_amount": 8,
+            "water_amount": 9,
+            "milk_amount": 10,
+            "milk_foam_amount": 11,
+        }
         for slot in range(9):
-            # Each amount has a distinct register offset on 8000 family
-            # (8, 9, 10, 11). The fake_read encoding mirrors that.
-            assert cached[slot]["coffee_amount"] == slot * 100 + 8
-            assert cached[slot]["water_amount"] == slot * 100 + 9
-            assert cached[slot]["milk_amount"] == slot * 100 + 10
-            assert cached[slot]["milk_foam_amount"] == slot * 100 + 11
+            for key, off in expected.items():
+                assert cached[slot][key] == slot * 100 + off, (
+                    f"slot {slot} {key}: expected offset {off}, got "
+                    f"register {cached[slot][key]}"
+                )
 
     async def test_skips_params_missing_from_layout(self, mock_bleak_client):
         """600 family has milk_foam_amount but no milk_amount offset —

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -216,10 +216,11 @@ async def test_total_cups_sensor_still_created_for_melitta(
 async def test_mycoffee_amount_sensors_registered_for_nivona_8000(
     hass: HomeAssistant, mock_entry: MockConfigEntry
 ) -> None:
-    """Nivona 8000 family — 9 slots × 4 amounts = 36 sensors.
+    """Nivona 8000 family — 9 slots × 7 params = 63 sensors.
 
-    Layout offsets for 8000 family include all four amounts
-    (coffee / water / milk / milk_foam), so all four register per slot.
+    Layout offsets for 8000 family include 4 amounts (coffee / water /
+    milk / milk_foam) plus enabled / strength / temperature. The 7
+    params register per slot.
     """
     client = _mock_client()  # default mock fits — we override below
     client.brand.brand_slug = "nivona"
@@ -237,16 +238,49 @@ async def test_mycoffee_amount_sensors_registered_for_nivona_8000(
         s for s in hass.states.async_all("sensor")
         if "mycoffee_slot_" in s.entity_id
     ]
-    assert len(mycoffee_sensors) == 36, (
-        f"Expected 36 mycoffee amount sensors for 8000 family (9 slots × 4 amounts); "
+    assert len(mycoffee_sensors) == 63, (
+        f"Expected 63 mycoffee sensors for 8000 family (9 slots × 7 params); "
         f"got {len(mycoffee_sensors)}: {[s.entity_id for s in mycoffee_sensors]}"
     )
-    # Each amount param appears once per slot.
-    for param in ("coffee_amount", "water_amount", "milk_amount", "milk_foam_amount"):
+    # Each param appears once per slot.
+    for param in (
+        "coffee_amount", "water_amount", "milk_amount", "milk_foam_amount",
+        "enabled", "strength", "temperature",
+    ):
         per_param = [s for s in mycoffee_sensors if param in s.entity_id]
         assert len(per_param) == 9, (
             f"Expected 9 sensors for {param}; got {len(per_param)}"
         )
+
+
+async def test_mycoffee_skips_temperature_on_1030_family(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """1030 / 1040 / 900 layouts use per-fluid temperatures and have
+    no plain `temperature_offset`. The sensor must skip the
+    `temperature` param on those families.
+    """
+    client = _mock_client()
+    client.brand.brand_slug = "nivona"
+    client.brand.brand_name = "Nivona"
+    client.brand.supported_extensions = frozenset()
+    caps = MagicMock()
+    caps.family_key = "1030"
+    # 1030 has 18 MyCoffee slots; we only need a few to verify gating.
+    caps.my_coffee_slots = 2
+    caps.stats = ()
+    client.capabilities = caps
+    client.my_coffee_slots = None
+    await _setup_integration(hass, mock_entry, client)
+
+    sensor_ids = [s.entity_id for s in hass.states.async_all("sensor")]
+    assert not any(
+        "mycoffee_slot_1_temperature" in eid for eid in sensor_ids
+    ), f"1030 family must not get a `temperature` sensor; saw {sensor_ids}"
+    # But enabled / strength / amounts are present.
+    assert any("mycoffee_slot_1_enabled" in eid for eid in sensor_ids)
+    assert any("mycoffee_slot_1_strength" in eid for eid in sensor_ids)
+    assert any("mycoffee_slot_1_coffee_amount" in eid for eid in sensor_ids)
 
 
 async def test_mycoffee_skips_params_missing_from_layout_600(


### PR DESCRIPTION
## Summary

Third slice on MyCoffee for the 0.78.0 batch. The bulk reader now also pulls three code/flag params alongside the four amounts:

- **`enabled`** — 0/1 flag, the slot's "armed" state.
- **`strength`** — bean-strength code 1..N (depends on `caps.strength_levels`).
- **`temperature`** — brew-temperature code 0..3. Single-byte-temperature families only (600 / 700 / 79x / 8000); 900 / 1030 / 1040 use per-fluid temperature offsets and skip this param.

### Layout-aware gating (unchanged contract)

The reader cycle still only fetches (slot, param) pairs whose offset is defined in the family's MyCoffee layout. No spurious "unavailable" sensors for params the hardware doesn't expose.

### Per-family sensor counts after this PR

| Family | Slots | Params exposed | Sensors |
|---|---|---|---|
| NIVO 8000 (NICR 8101 etc.) | 9 | 7 (4 amounts + enabled + strength + temperature) | **63** |
| NICR 1040 | 18 | 6 (no temperature) | **108** |
| NICR 1030 | 18 | 6 (no temperature) | **108** |
| NICR 700 / 79x / 900 / 900-light | per-model (1–9) | 6–7 (depending on temperature) | up to 63 |
| NICR 600 | 1–5 (per-model) | 6 (no milk_amount) | up to 30 |

All under `EntityCategory.DIAGNOSTIC` — tucked into HA's diagnostic group.

### Tests

- New: `test_mycoffee_skips_temperature_on_1030_family` — verifies the layout-aware skip on 1030's per-fluid-temp layout.
- Updated: `test_mycoffee_amount_sensors_registered_for_nivona_8000` asserts the new count (9 × 7 = 63) and that each of the 7 param keys appears 9 times.
- Updated: `test_reads_all_four_amounts_per_slot` (kept the name for git-blame continuity but now exercises all 7 params per slot via register-offset encoding).
- Full suite: **982 passed** (was 981 on the previous batch commit).

### Release

This PR does **not** tag a release. Bundled with PR D (factory-reset buttons), PR E (MyCoffee bulk-read base), and #23 (4-amount expansion) into a single **0.78.0** release once the batch is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)