### PR TITLE
feat: Brew MyCoffee slot N buttons for Nivona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,13 @@ All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
   Foundation for the broader MyCoffee CRUD work — write support and code-style params (profile, two_cups, per-fluid temperatures) will follow in later releases.
 
+- **Per-slot "Brew MyCoffee slot N" buttons** for Nivona. One button per slot (1..my_coffee_slots) — sends HE with the saved recipe (no temp-recipe write). Press is gated at runtime on the slot's cached `enabled` flag — slots that aren't "armed" stay unavailable so users don't accidentally fire an empty recipe. Button display number is 1-indexed (display "Brew MyCoffee slot 1" → cache slot 0 → HE `payload[3] = 20`).
+
 ### Tests
 - 8 new tests for the factory-reset path (`tests/test_protocol.py::TestExecuteCommand` + `tests/test_button.py`).
 - 6 new tests for MyCoffee bulk read (`tests/test_ble_client.py::TestReadMyCoffeeSlots`) + 4 sensor-registration tests (`tests/test_sensor.py`).
-- Full suite: 982 passed (was 964 on v0.77.1).
+- 5 new tests for the brew-by-slot path (`tests/test_ble_client.py::TestBrewMyCoffeeSlot`) + 3 button tests (registration count, availability gating, press wiring).
+- Full suite: 990 passed (was 964 on v0.77.1).
 
 ## [0.77.1] — 2026-05-28
 

--- a/custom_components/melitta_barista/_ble_commands.py
+++ b/custom_components/melitta_barista/_ble_commands.py
@@ -205,6 +205,46 @@ class BleCommandsMixin(_MixinBase):
                 if self.connected:
                     self.start_polling(interval=self._poll_interval)
 
+    async def brew_mycoffee_slot(self, slot: int) -> bool:
+        """Brew the MyCoffee recipe saved in slot ``slot``.
+
+        Wire path: HE with ``payload[3] = first_mycoffee_selector + slot``
+        and ``payload[5] = 0`` (use saved recipe defaults — the slot's
+        recipe is already persisted on the machine). No temp-recipe
+        write involved; this is the simplest brew variant.
+
+        Returns ``False`` if not connected, machine not ready, no
+        capabilities resolved, or ``slot`` out of range.
+        """
+        if self._brew_lock.locked():
+            _LOGGER.warning("Brew already in progress, ignoring")
+            return False
+        if not self.connected:
+            return False
+        caps = getattr(self, "_capabilities", None)
+        if caps is None:
+            return False
+        if slot < 0 or slot >= caps.my_coffee_slots:
+            return False
+        if not self._is_brew_ready():
+            _LOGGER.warning("Machine not ready: %s", self._status)
+            return False
+
+        brew_mode = caps.brew_command_mode
+        selector = caps.first_mycoffee_selector + slot
+
+        async with self._brew_lock:
+            self._stop_polling()
+            try:
+                return await self._protocol.start_process_nivona(
+                    self._write_ble, selector, brew_mode,
+                    use_temp_recipe=False,
+                    chilled=False,
+                )
+            finally:
+                if self.connected:
+                    self.start_polling(interval=self._poll_interval)
+
     async def brew_directkey(self, category: DirectKeyCategory, *, two_cups: bool = False) -> bool:
         """Brew from a DirectKey slot of the active profile.
 

--- a/custom_components/melitta_barista/button.py
+++ b/custom_components/melitta_barista/button.py
@@ -13,7 +13,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .ble_client import MelittaBleClient
+from homeassistant.const import CONF_ADDRESS
+from .ble_client import MelittaBleClient, resolve_caps_from_scanner
 from .const import (
     FREESTYLE_RECIPE_TYPE, HE_CMD_FACTORY_RESET_RECIPES,
     HE_CMD_FACTORY_RESET_SETTINGS, PROMPT_MANIPULATIONS, RECIPE_NAMES,
@@ -73,6 +74,21 @@ async def async_setup_entry(
     if client.brand.brand_slug == "nivona":
         entities.append(NivonaFactoryResetSettingsButton(client, entry, name))
         entities.append(NivonaFactoryResetRecipesButton(client, entry, name))
+
+        # Per-slot MyCoffee brew buttons. Selector resolved as
+        # `first_mycoffee_selector + slot` (vendor uses 20 as the
+        # base for every Nivona model). Press is gated at runtime on
+        # the slot's cached `enabled` flag — slots that aren't
+        # "armed" stay unavailable so users don't accidentally fire
+        # an empty recipe.
+        caps_for_brew = client.capabilities
+        if caps_for_brew is None:
+            caps_for_brew = resolve_caps_from_scanner(
+                hass, entry.data.get(CONF_ADDRESS, ""), client.brand,
+            )
+        if caps_for_brew is not None and caps_for_brew.my_coffee_slots > 0:
+            for slot in range(caps_for_brew.my_coffee_slots):
+                entities.append(NivonaBrewMyCoffeeButton(client, entry, name, slot))
 
     # Maintenance buttons
     entities.append(MelittaMaintenanceButton(
@@ -552,3 +568,61 @@ class MelittaMaintenanceButton(_MelittaButtonBase):
                 _LOGGER.error("Failed to start %s", self._attr_name)
         except (BleakError, OSError, asyncio.TimeoutError):
             _LOGGER.exception("BLE error while starting %s", self._attr_name)
+
+
+class NivonaBrewMyCoffeeButton(_MelittaButtonBase):
+    """Brew a saved MyCoffee recipe by slot (Nivona only).
+
+    One button per slot 0..N-1, where N is the family's
+    `my_coffee_slots`. Gated at runtime on:
+    - client.connected
+    - machine status `is_ready_for_brew`
+    - the slot's cached `enabled` flag (so slots that aren't armed
+      stay unavailable instead of firing an empty recipe)
+    """
+
+    _attr_icon = "mdi:coffee-to-go"
+
+    def __init__(
+        self,
+        client: MelittaBleClient,
+        entry: ConfigEntry,
+        name: str,
+        slot: int,
+    ) -> None:
+        super().__init__(client, entry, name)
+        self._slot = slot
+        self._attr_name = f"Brew MyCoffee slot {slot + 1}"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._client.address}_brew_mycoffee_slot_{self._slot}"
+
+    @property
+    def available(self) -> bool:
+        if not self._client.connected:
+            return False
+        status = self._client.status
+        # Be permissive on tolerated manipulation flags so the button
+        # follows the same readiness contract as the main brew button.
+        caps = getattr(self._client, "capabilities", None)
+        tolerated = caps.tolerated_brew_manipulations if caps else ()
+        if status is None or not status.is_ready_for_brew(tolerated):
+            return False
+        slots = self._client.my_coffee_slots
+        if slots is None or self._slot >= len(slots):
+            return False
+        return slots[self._slot].get("enabled", 0) == 1
+
+    async def async_press(self) -> None:
+        _LOGGER.info("Brewing MyCoffee slot %d", self._slot + 1)
+        try:
+            success = await self._client.brew_mycoffee_slot(self._slot)
+            if not success:
+                _LOGGER.error(
+                    "Failed to start MyCoffee brew for slot %d", self._slot + 1,
+                )
+        except (BleakError, OSError, asyncio.TimeoutError):
+            _LOGGER.exception(
+                "BLE error while brewing MyCoffee slot %d", self._slot + 1,
+            )

--- a/tests/test_ble_client.py
+++ b/tests/test_ble_client.py
@@ -3590,3 +3590,72 @@ class TestReadMyCoffeeSlots:
         )
         # milk_foam_amount IS in 600 layout (offset 11), so it must be present.
         assert "milk_foam_amount" in cached[0]
+
+
+# ---------------------------------------------------------------------------
+# brew_mycoffee_slot — Nivona MyCoffee brew (PR — 0.78.0 batch)
+# ---------------------------------------------------------------------------
+
+class TestBrewMyCoffeeSlot:
+    """Brew a saved MyCoffee recipe stored in slot N.
+
+    Wire path: HE with `payload[3] = first_mycoffee_selector + N` and
+    `payload[5] = 0` (use saved recipe defaults). No temp-recipe write
+    — the slot's recipe is already persisted on the machine.
+    """
+
+    async def test_returns_false_when_not_connected(self):
+        client = MelittaBleClient("AA:BB:CC:DD:EE:FF")
+        assert await client.brew_mycoffee_slot(0) is False
+
+    async def test_returns_false_without_capabilities(self, mock_bleak_client):
+        from custom_components.melitta_barista.brands.nivona import NivonaProfile
+        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
+        client._capabilities = None
+        client._status = MagicMock(is_ready_for_brew=MagicMock(return_value=True))
+        assert await client.brew_mycoffee_slot(0) is False
+
+    async def test_returns_false_for_out_of_range_slot(self, mock_bleak_client):
+        from custom_components.melitta_barista.brands.nivona import NivonaProfile
+        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
+        client._capabilities = NivonaProfile().capabilities_for_model(
+            "NIVONA-8101000000-----",
+        )
+        client._status = MagicMock(is_ready_for_brew=MagicMock(return_value=True))
+        # 8000 family → 9 slots, valid slots 0..8.
+        assert await client.brew_mycoffee_slot(9) is False
+        assert await client.brew_mycoffee_slot(-1) is False
+
+    async def test_returns_false_when_not_ready(self, mock_bleak_client):
+        from custom_components.melitta_barista.brands.nivona import NivonaProfile
+        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
+        client._capabilities = NivonaProfile().capabilities_for_model(
+            "NIVONA-8101000000-----",
+        )
+        client._status = MagicMock(is_ready_for_brew=MagicMock(return_value=False))
+        assert await client.brew_mycoffee_slot(0) is False
+
+    async def test_calls_start_process_nivona_with_correct_selector(
+        self, mock_bleak_client,
+    ):
+        """slot N → recipe_selector = 20 + N, use_temp_recipe=False."""
+        from custom_components.melitta_barista.brands.nivona import NivonaProfile
+        client = _make_connected_client(mock_bleak_client, brand=NivonaProfile())
+        client._capabilities = NivonaProfile().capabilities_for_model(
+            "NIVONA-8101000000-----",
+        )
+        assert client._capabilities.first_mycoffee_selector == 20
+        client._status = MagicMock(is_ready_for_brew=MagicMock(return_value=True))
+        client._protocol.start_process_nivona = AsyncMock(return_value=True)
+
+        result = await client.brew_mycoffee_slot(3)
+        assert result is True
+
+        client._protocol.start_process_nivona.assert_awaited_once()
+        kwargs = client._protocol.start_process_nivona.await_args.kwargs
+        args = client._protocol.start_process_nivona.await_args.args
+        # signature: (write_func, recipe_selector, brew_mode, *, use_temp_recipe, chilled)
+        # Selector = 20 + 3 = 23, use_temp_recipe must be False.
+        assert args[1] == 23, f"expected selector 23 (= 20 + slot 3); got {args[1]}"
+        assert kwargs.get("use_temp_recipe") is False
+        assert kwargs.get("chilled") is False

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -714,3 +714,82 @@ async def test_factory_reset_recipes_press_invokes_command_51(
         "button", "press", {"entity_id": recipes_eid}, blocking=True,
     )
     client.execute_he_command.assert_awaited_with(51)
+
+
+async def test_mycoffee_brew_buttons_registered_for_nivona_8000(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """9 slots on 8000 family → 9 brew-MyCoffee buttons."""
+    client = _mock_nivona_client(family_key="8000")
+    client.capabilities.my_coffee_slots = 9
+    client.my_coffee_slots = None
+    await _setup_integration(hass, mock_entry, client)
+
+    brew_buttons = [
+        s.entity_id for s in hass.states.async_all("button")
+        if "brew_mycoffee_slot_" in s.entity_id
+    ]
+    assert len(brew_buttons) == 9, brew_buttons
+
+
+async def test_mycoffee_brew_buttons_unavailable_when_slot_not_enabled(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Slot N's button stays unavailable if the cached `enabled` flag is 0."""
+    client = _mock_nivona_client(family_key="8000")
+    client.capabilities.my_coffee_slots = 3
+    # Simulate post-connect cache: only slot 1 is armed.
+    client.my_coffee_slots = [
+        {"enabled": 0, "coffee_amount": 0},
+        {"enabled": 1, "coffee_amount": 40},
+        {"enabled": 0, "coffee_amount": 0},
+    ]
+    # Real-shape status — other platforms inspect `.process` and trip
+    # over a plain MagicMock substitution.
+    client.status = MachineStatus(process=MachineProcess.READY)
+
+    await _setup_integration(hass, mock_entry, client)
+
+    states = {
+        s.entity_id: s.state
+        for s in hass.states.async_all("button")
+        if "brew_mycoffee_slot_" in s.entity_id
+    }
+    # Entity ids are 1-indexed (derived from the display name
+    # "Brew MyCoffee slot N+1"). Slots 0/2 (cache index) → display
+    # 1/3 → unavailable. Slot 1 → display 2 → available.
+    slot_eids = {eid.rsplit("_", 1)[-1]: eid for eid in states}
+    assert states[slot_eids["1"]] == "unavailable", states
+    assert states[slot_eids["2"]] != "unavailable", (
+        f"slot 1 (display 2) should be available; got {states[slot_eids['2']]}"
+    )
+    assert states[slot_eids["3"]] == "unavailable", states
+
+
+async def test_mycoffee_brew_button_press_invokes_brew_mycoffee_slot(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
+    """Pressing the slot-N button calls brew_mycoffee_slot(N)."""
+    client = _mock_nivona_client(family_key="8000")
+    client.capabilities.my_coffee_slots = 4
+    client.my_coffee_slots = [
+        {"enabled": 1, "coffee_amount": 30},  # slot 0
+        {"enabled": 1, "coffee_amount": 40},
+        {"enabled": 1, "coffee_amount": 50},
+        {"enabled": 1, "coffee_amount": 60},
+    ]
+    client.status = MachineStatus(process=MachineProcess.READY)
+    client.brew_mycoffee_slot = AsyncMock(return_value=True)
+
+    await _setup_integration(hass, mock_entry, client)
+
+    # Entity id is 1-indexed; press the display-3 entity, which maps
+    # to cache slot index 2.
+    slot3_eid = next(
+        s.entity_id for s in hass.states.async_all("button")
+        if s.entity_id.endswith("_brew_mycoffee_slot_3")
+    )
+    await hass.services.async_call(
+        "button", "press", {"entity_id": slot3_eid}, blocking=True,
+    )
+    client.brew_mycoffee_slot.assert_awaited_with(2)


### PR DESCRIPTION
## Summary

Fifth slice in the 0.78.0 batch. Adds per-slot "Brew MyCoffee slot N" buttons for Nivona.

### Wire path

For each slot 0..N-1 a button entity is registered. Pressing slot N fires:

```
HE.payload[3] = caps.first_mycoffee_selector + N   # 20 + N
HE.payload[5] = 0                                  # use saved recipe (no temp-recipe write)
```

`first_mycoffee_selector` is the constant added in v0.77.1; for every Nivona model it's `20`. So display "Brew MyCoffee slot 1" → cache index 0 → selector `20`. Display "Brew MyCoffee slot 9" → selector `28`.

### Availability gating

Buttons stay `unavailable` when any of the following is false:

1. `client.connected`
2. `status.is_ready_for_brew(tolerated_brew_manipulations)` — same readiness contract as the standard brew button
3. **`my_coffee_slots[slot].get("enabled", 0) == 1`** — the slot's cached `enabled` flag from PR #24's bulk read

Slot 3 (display 4) registers a button even if `enabled = 0`, but stays unavailable in the UI. As soon as the user arms the slot in the machine, the next bulk-read cycle flips `enabled` to 1 and the button becomes available.

### UX note: 1-indexed display, 0-indexed cache

`_attr_name = f"Brew MyCoffee slot {slot + 1}"` ⇒ HA-generated entity_id is `button.<name>_brew_mycoffee_slot_<N+1>`. The unique_id keeps the 0-indexed cache slot for stable identifiers (`<addr>_brew_mycoffee_slot_<N>`).

### Tests

- 5 new method tests (`tests/test_ble_client.py::TestBrewMyCoffeeSlot`):
  - returns False when not connected / no capabilities / out-of-range slot / not ready
  - on happy path → calls `protocol.start_process_nivona(write_func, selector=23, brew_mode=4, use_temp_recipe=False, chilled=False)` for slot 3 on 8000 family
- 3 new button-platform tests:
  - 9 buttons registered for 9-slot 8000 family
  - mixed enabled flags → cache slots 0 and 2 stay unavailable, cache slot 1 is available
  - press wiring → `client.brew_mycoffee_slot(N)` called
- Full suite: **990 passed** (was 982 on the previous batch commit).

### Release

This PR does **not** tag a release. Closes out the MyCoffee read+brew slice for the **0.78.0** batch (D = factory reset, E = bulk-read base, #23 = 4 amounts, #24 = enabled/strength/temperature, this PR = brew button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)