### PR TITLE
chore(release): 0.78.0 — factory reset + MyCoffee read/brew for Nivona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
-## [Unreleased] — 0.78.0
+## [0.78.0] — 2026-05-28
 
 ### Added
 

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -31,5 +31,5 @@
     "aiosqlite>=0.19.0",
     "pydantic>=2.0"
   ],
-  "version": "0.77.1"
+  "version": "0.78.0"
 }


### PR DESCRIPTION
## Summary

Release bump for **0.78.0**. Bundles five merged PRs (#20 #22 #23 #24 #25) — factory reset buttons + the MyCoffee read+brew slice for Nivona.

### What ships in 0.78.0

**Factory reset buttons** (Nivona, families 600 / 700 / 79x / 900 / 900-light / 1030 / 1040 — NOT 8000):
- "Factory Reset Settings"  — HE commandId 50
- "Factory Reset Recipes"   — HE commandId 51
- `device_class=restart` so HA dashboards prompt a confirm dialog

**MyCoffee** (Nivona):
- Bulk read on every connect — 4 amounts + enabled + strength + temperature, gated by per-family MyCoffee layout
- Per-(slot, param) diagnostic sensors (NIVO 8000 → 63; NICR 1040 → 108; NICR 600 → up to 30)
- Per-slot "Brew MyCoffee slot N" buttons; availability follows the cached `enabled` flag

### Tests

990 passed (was 964 on v0.77.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)