### PR TITLE
docs+fix: address issue #14 follow-ups — Docker HA Container troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Melitta Barista Smart & Nivona HA Integration.
 
+## [0.79.1] — 2026-05-28
+
+### Added
+
+- **README troubleshooting section for Docker HA Container users**. Three host-side prerequisites that are commonly missed and surface as misleading `HU handshake timeout` / `Authentication failed` errors (per issue #14): host `bluez` package install, `/run/dbus:/run/dbus:ro` socket mount, `--privileged` + `--net=host` container flags. Includes BlueZ cache-reset recipe.
+- **`HCL.md` row for Apple Broadcom BCM2046B1 / BCM20702A0** (USB ID `05ac:828d`) graduated to ✅ verified, with full diagnostic context: Ubuntu 24.04 + HA Container + BlueZ 5.72, NICR 779 (Nivona 7xx) end-to-end.
+
+### Fixed
+
+- **Misleading `ble_agent` log when D-Bus is unreachable.** Previously a Docker user without `/run/dbus` mounted would see "Assuming ESPHome BLE proxy" — incorrect and misleading. The log now explicitly names both valid scenarios (ESPHome proxy → expected; Docker without D-Bus mount → broken setup) and points to the README troubleshooting section.
+
 ## [0.79.0] — 2026-05-28
 
 ### Refactored

--- a/HCL.md
+++ b/HCL.md
@@ -87,6 +87,7 @@ issues are typically here.
 | **Intel Wireless 7265 / 8260 / 8265 / AX200 / AX201 / AX210** | Intel | 👥 community-confirmed | Standard Linux BlueZ path. Reliable. |
 | **CSR8510 USB dongle** | CSR / Qualcomm | 👥 community-confirmed | The classic $5 BLE dongle. Verified through unrelated HA integrations; assumed-good here. |
 | **TP-Link UB500 / UB400** | RTL8761B | 👥 community-confirmed | Needs `rtl_bt_*` firmware on Debian-style distros. Otherwise drop-in. |
+| **Apple Broadcom built-in (Mac mini / iMac)** | BCM2046B1 / BCM20702A0 (USB ID `05ac:828d`) | ✅ verified (#14) | Full-stack verified on Ubuntu 24.04 + HA Container + BlueZ 5.72 with NICR 779 (Nivona 7xx). HCI/LMP 4.0, manufacturer ID `0x000f`. |
 | **Built-in BLE on `homeassistant.local` HA OS** | varies (host hardware) | 👥 case-by-case | Most failures here come down to `bluetoothd` cache or stale pairing — see the troubleshooting notes below and in #14. |
 
 #### Known headless-Linux quirks (from #14)
@@ -97,16 +98,44 @@ issues are typically here.
   machine in pair mode.
 - `bluetoothd` can SEGFAULT on certain pairing-cancel paths if no D-Bus
   agent is registered when the request arrives. The integration's
-  `_NoInputOutputAgent` covers this; if you see a fresh report, the
-  agent-registration path may need to be extended to cover continuous
-  reconnects too (tracked in #14 part 2).
+  `_NoInputOutputAgent` covers this.
 
 ### 1.3 BlueZ on Docker / VPS without a desktop session
 
 Same as 1.2 but specifically headless. The D-Bus pairing agent in the
 integration is what unblocks this — there's no Blueman / gnome-bluetooth
-helper to fall back on. If something breaks here, please include
-`bluetoothctl show` output in the bug report.
+helper to fall back on.
+
+**Container prerequisites (often missed — root cause of "HU handshake
+timeout" misdiagnoses, see #14 follow-up)**:
+
+1. **`bluez` must be installed on the host** (NOT just `bluez-obexd`).
+   Without `bluetoothd` running on the host, no GATT pairing happens
+   even though the integration loads cleanly.
+   ```bash
+   sudo apt update && sudo apt install -y bluez
+   sudo systemctl enable --now bluetooth
+   ```
+
+2. **D-Bus socket must be mounted into the container.** Add to your
+   `docker run` / `docker-compose` config:
+   ```yaml
+   volumes:
+     - /run/dbus:/run/dbus:ro
+   ```
+   Without this, the integration cannot talk to `bluetoothd` at all and
+   `Authentication failed` / `No agent available` errors surface during
+   first pairing.
+
+3. **`--privileged` or capability `NET_ADMIN` + `BLUETOOTH_ADMIN`**
+   typically required for BLE scanning from inside a container.
+
+4. **Network mode `host`** recommended (matches HA's expected
+   discovery behaviour).
+
+If something still breaks after these prerequisites, please include
+`bluetoothctl show` output and `dmesg | grep -i bluetooth` in the bug
+report.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,43 @@ The repo ships a ready-to-flash ESPHome config at
 **Seeed XIAO ESP32-C6** (the maintainer's reference board). Any ESP32 / S3 /
 C3 / C6 with stock `bluetooth_proxy` works the same way.
 
+### Running HA in a Docker container? Three host-side prerequisites
+
+If you run **Home Assistant Container** (Docker) and want to use the host's
+local Bluetooth adapter (not an ESPHome proxy), three prerequisites are
+often missed and surface as confusing `HU handshake timeout` /
+`Authentication failed` errors:
+
+1. **Install `bluez` on the host** (the full daemon, not just `bluez-obexd`):
+   ```bash
+   sudo apt update && sudo apt install -y bluez
+   sudo systemctl enable --now bluetooth
+   ```
+   Without `bluetoothd` running on the host, GATT pairing never completes.
+
+2. **Mount the D-Bus socket into the container.** Add to `docker run` or
+   `docker-compose.yml`:
+   ```yaml
+   volumes:
+     - /run/dbus:/run/dbus:ro
+   ```
+
+3. **Use `--privileged` or grant `NET_ADMIN` capability**, and run with
+   `--net=host`. These match HA's expected discovery behaviour and let the
+   integration scan + connect over the host BLE stack.
+
+If a previously-attempted machine is stuck, reset its BlueZ cache from the
+host:
+```bash
+bluetoothctl disconnect <MAC>
+bluetoothctl remove <MAC>
+# then put the machine in pair mode and re-add the integration
+```
+
+Verified working: NICR 779 on Mac mini (Apple Broadcom BCM2046B1) /
+Ubuntu 24.04 / BlueZ 5.72 / HA Container — see [`HCL.md`](HCL.md) for the
+full hardware list.
+
 ---
 
 ## Requirements

--- a/custom_components/melitta_barista/ble_agent.py
+++ b/custom_components/melitta_barista/ble_agent.py
@@ -199,14 +199,29 @@ async def async_pair_device(address: str, timeout: float = 30.0) -> str:
         try:
             bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
         except Exception:  # noqa: BLE001 — dbus_fast raises many shapes
-            # No reachable system D-Bus (typical in HA OS containers
-            # without a host BlueZ stack). Functionally equivalent to
-            # "no Adapter1" — the device is reached via an ESPHome BLE
-            # proxy that handles bonding at the ESP32 level. Reported
-            # in #15.
+            # System D-Bus not reachable. Two valid scenarios:
+            #
+            #   1. ESPHome BLE proxy in use — bonding handled at the
+            #      ESP32 level, no host D-Bus needed. Continuing is
+            #      correct here.
+            #   2. Local BLE adapter via Docker / VPS where /run/dbus
+            #      is not mounted into the container — bonding WILL
+            #      fail later with "Authentication failed" or
+            #      "No agent available" because BlueZ has no agent
+            #      to talk to even though the adapter is there.
+            #
+            # We can't reliably tell the two apart from inside the
+            # pairing function (would require HA's bluetooth scanner
+            # registry). Continue optimistically; if Bleak's
+            # `pair=True` later fails, the README troubleshooting
+            # section ("Running HA in a Docker container") covers
+            # the remediation. Reported in #14 / #15.
             _LOGGER.info(
-                "System D-Bus not reachable. "
-                "Assuming ESPHome BLE proxy — skipping D-Bus pairing for %s",
+                "System D-Bus not reachable for %s — skipping D-Bus pairing. "
+                "If this is an ESPHome BLE proxy setup, this is expected. "
+                "If using a local BLE adapter via Docker, ensure /run/dbus "
+                "is mounted into the container and the host has `bluez` "
+                "installed — see README troubleshooting section.",
                 address,
             )
             return "ok"

--- a/custom_components/melitta_barista/manifest.json
+++ b/custom_components/melitta_barista/manifest.json
@@ -31,5 +31,5 @@
     "aiosqlite>=0.19.0",
     "pydantic>=2.0"
   ],
-  "version": "0.79.0"
+  "version": "0.79.1"
 }


### PR DESCRIPTION
Closes #14.

Three follow-ups from issue #14 (NICR 779 / Nivona 7xx on headless Linux + HA Container) after user verification that v0.74.2 already resolved the regex bug and the "headless pairing" concern was actually a host-side configuration issue (host missing `bluez`, Docker container missing `/run/dbus` mount).

## Changes

### README

New "Running HA in a Docker container?" troubleshooting section under BLE topology. Three concrete prerequisites that surface as misleading `HU handshake timeout` / `Authentication failed` errors when missed:

1. Install `bluez` on the host (the full daemon, not just `bluez-obexd`)
2. Mount `/run/dbus:/run/dbus:ro` into the container
3. Run with `--privileged` (or `NET_ADMIN`) + `--net=host`

Plus a BlueZ cache-reset recipe (`bluetoothctl disconnect <MAC>` / `remove <MAC>`).

### `HCL.md`

- Graduate Apple Broadcom **BCM2046B1 / BCM20702A0** (USB ID `05ac:828d`) row to ✅ **verified** — first 7xx-family + Docker datapoint we have full diagnostic data for (Ubuntu 24.04 / BlueZ 5.72 / HA Container).
- Expand §1.3 (BlueZ on Docker / VPS) with the same container prerequisites plus diagnostics suggestions.
- Remove stale "tracked in #14 part 2" reference since part 2 turned out not to be a code issue.

### `ble_agent.py`

Improve diagnostic log when D-Bus is unreachable. Previously: "Assuming ESPHome BLE proxy" — misleading for Docker users where the local adapter IS there but the integration just can't reach `bluetoothd`. Now: explicitly names both valid scenarios (ESPHome proxy = expected; Docker without D-Bus mount = broken setup), points to README troubleshooting.

Verbose comment explains the two-scenarios situation since we can't reliably disambiguate from inside the pairing function.

## Version

0.79.0 → **0.79.1** (PATCH — docs + tiny log message fix, no behavior change).

## Test plan

- [x] `pytest tests/ -q` = 992 passed (unchanged from v0.79.0)
- [x] Issue #14 reporter (`sharonovstan-spec`) provided full diagnostic data; HCL row reflects his setup exactly
- [x] README troubleshooting steps come directly from his reproduction (verified working on his end before he submitted them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)